### PR TITLE
Tolerate missing Visual Studio installation on Windows

### DIFF
--- a/NuGetUtility.sln
+++ b/NuGetUtility.sln
@@ -1,5 +1,4 @@
-﻿﻿﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/src/NuGetUtility/Wrapper/MsBuildWrapper/WindowsMsBuildAbstraction.cs
+++ b/src/NuGetUtility/Wrapper/MsBuildWrapper/WindowsMsBuildAbstraction.cs
@@ -33,11 +33,19 @@ namespace NuGetUtility.Wrapper.MsBuildWrapper
             // https://learn.microsoft.com/en-us/visualstudio/install/tools-for-managing-visual-studio-instances?view=vs-2022#using-windows-management-instrumentation-wmi
 
             var result = new List<string>();
-            var mmc = new ManagementClass("root/cimv2/vs:MSFT_VSInstance");
 
-            foreach (ManagementBaseObject? vs_instance in mmc.GetInstances())
-                if (vs_instance["InstallLocation"] is string install_path)
-                    result.Add(install_path);
+            try
+            {
+                var mmc = new ManagementClass("root/cimv2/vs:MSFT_VSInstance");
+
+                foreach (ManagementBaseObject? vs_instance in mmc.GetInstances())
+                    if (vs_instance["InstallLocation"] is string install_path)
+                        result.Add(install_path);
+            }
+            catch (ManagementException me) when (me.Message.Contains("Invalid namespace"))
+            {
+                // Visual Studio might not be installed
+            }
 
             return result;
         }


### PR DESCRIPTION
When running on Windows and there's no Visual Studio installation present, I get:

```
System.Exception: Received err output: Unhandled exception. System.Management.ManagementException: Invalid namespace
   at System.Management.ManagementException.ThrowWithExtendedInfo(ManagementStatus errorCode)
   at System.Management.ManagementScope.InitializeGuts(Object o)
   at System.Management.ManagementScope.Initialize()
   at System.Management.ManagementObject.Initialize(Boolean getObject)
   at System.Management.ManagementClass.GetInstances(EnumerationOptions options)
   at System.Management.ManagementClass.GetInstances()
   at NuGetUtility.Wrapper.MsBuildWrapper.WindowsMsBuildAbstraction.GetVisualStudioInstallPaths() in /home/runner/work/nuget-license/nuget-license/src/NuGetUtility/Wrapper/MsBuildWrapper/WindowsMsBuildAbstraction.cs:line 38
   at NuGetUtility.Wrapper.MsBuildWrapper.WindowsMsBuildAbstraction.GetBestVCTargetsPath() in /home/runner/work/nuget-license/nuget-license/src/NuGetUtility/Wrapper/MsBuildWrapper/WindowsMsBuildAbstraction.cs:line 24
   at NuGetUtility.Wrapper.MsBuildWrapper.WindowsMsBuildAbstraction..ctor() in /home/runner/work/nuget-license/nuget-license/src/NuGetUtility/Wrapper/MsBuildWrapper/WindowsMsBuildAbstraction.cs:line 14
   at NuGetUtility.Program.OnExecuteAsync(CancellationToken cancellationToken) in /home/runner/work/nuget-license/nuget-license/src/NuGetUtility/Program.cs:line 102
```

Adding try-catch to tolerate it, also removed invalid characters from beginning from solution file which prohibited opening the solution in Rider.