### PR TITLE
Add/license url override

### DIFF
--- a/src/NuGetUtility/PackageInformationReader/CustomPackageInformation.cs
+++ b/src/NuGetUtility/PackageInformationReader/CustomPackageInformation.cs
@@ -5,5 +5,5 @@ using NuGetUtility.Wrapper.NuGetWrapper.Versioning;
 
 namespace NuGetUtility.PackageInformationReader
 {
-    public record struct CustomPackageInformation(string Id, INuGetVersion Version, string License, string? Copyright = null, string? Authors = null, string? Title = null, string? ProjectUrl = null, string? Summary = null, string? Description = null);
+    public record struct CustomPackageInformation(string Id, INuGetVersion Version, string License, Uri? LicenseUrl = null, string? Copyright = null, string? Authors = null, string? Title = null, string? ProjectUrl = null, string? Summary = null, string? Description = null);
 }

--- a/src/NuGetUtility/PackageInformationReader/PackageMetadata.cs
+++ b/src/NuGetUtility/PackageInformationReader/PackageMetadata.cs
@@ -26,7 +26,7 @@ namespace NuGetUtility.PackageInformationReader
 
         public string? Title => CustomPackageInformation?.Title;
 
-        public Uri? LicenseUrl => null;
+        public Uri? LicenseUrl => CustomPackageInformation?.LicenseUrl;
 
         public string? ProjectUrl => CustomPackageInformation?.ProjectUrl;
 

--- a/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
+++ b/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
@@ -95,6 +95,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             Assert.That(packages, Is.EquivalentTo(result.Select(s => new CustomPackageInformation(s.PackageInfo.Identity.Id,
                                                                 s.PackageInfo.Identity.Version,
                                                                 s.PackageInfo.LicenseMetadata!.License,
+                                                                s.PackageInfo.LicenseUrl,
                                                                 s.PackageInfo.Copyright,
                                                                 s.PackageInfo.Authors,
                                                                 s.PackageInfo.Title,

--- a/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
+++ b/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
@@ -126,6 +126,7 @@ namespace NuGetUtility.Test.PackageInformationReader
                 mockedInfo.Summary.Returns(info.Summary);
                 mockedInfo.Description.Returns(info.Description);
                 mockedInfo.LicenseMetadata.Returns(new LicenseMetadata(LicenseType.Expression, info.License));
+                mockedInfo.LicenseUrl.Returns(info.LicenseUrl);
                 _globalPackagesFolderUtility.GetPackage(identity).Returns(mockedInfo);
 
                 return identity;
@@ -148,6 +149,7 @@ namespace NuGetUtility.Test.PackageInformationReader
                 IPackageMetadata resultingInfo = Substitute.For<IPackageMetadata>();
                 resultingInfo.Identity.Returns(new PackageIdentity(package.Id, package.Version));
                 resultingInfo.LicenseMetadata.Returns(new LicenseMetadata(LicenseType.Expression, package.License));
+                resultingInfo.LicenseUrl.Returns(package.LicenseUrl);
                 resultingInfo.Copyright.Returns(package.Copyright);
                 resultingInfo.Authors.Returns(package.Authors);
                 resultingInfo.Title.Returns(package.Title);


### PR DESCRIPTION
Hello,

When testing the capabilities of the tool, I noticed the URL could not be overridden by the option "override-package-information". 

For many reasons URLs may be broken (domain name changing/expiring, changing SCM provider, etc). If we were to attempt the download of the original license, it would fail. 

One such package I encountered is [SharpDX](https://www.nuget.org/packages/SharpDX), which still has the invalid URL linked on nuget.org : 
* Invalid: http://sharpdx.org/License.txt
* Still active: https://github.com/sharpdx/SharpDX/blob/v4.2.0/License.txt

Following what was written in #53 and #68 I also added the LicenceUrl to the list of fields and to the tests.

