### PR TITLE
Add support for filtering shared VS projects

### DIFF
--- a/src/NuGetUtility/Program.cs
+++ b/src/NuGetUtility/Program.cs
@@ -312,7 +312,7 @@ namespace NuGetUtility
             var result = new List<ProjectWithReferencedPackages>();
             exceptions = encounteredExceptions;
 
-            IEnumerable<string> filteredProjects = ProjectFilterer.Instance.FilterProjects(projects, IncludeSharedProjects);
+            IEnumerable<string> filteredProjects = new ProjectFilterer().FilterProjects(projects, IncludeSharedProjects);
 
             foreach (string project in filteredProjects)
             {

--- a/src/NuGetUtility/Program.cs
+++ b/src/NuGetUtility/Program.cs
@@ -15,6 +15,7 @@ using NuGetUtility.Output;
 using NuGetUtility.Output.Json;
 using NuGetUtility.Output.Table;
 using NuGetUtility.PackageInformationReader;
+using NuGetUtility.ProjectFiltering;
 using NuGetUtility.ReferencedPackagesReader;
 using NuGetUtility.Serialization;
 using NuGetUtility.Wrapper.HttpClientWrapper;
@@ -93,6 +94,11 @@ namespace NuGetUtility
             ShortName = "exclude-projects",
             Description = "This option allows to specify project name(s) to exclude from the analysis. This can be useful to exclude test projects from the analysis when supplying a solution file as input. Wildcard characters (*) are supported to specify ranges of ignored projects. The input can either be a file name containing a list of project names in json format or a plain string that is then used as a single entry.")]
         public string? ExcludedProjects { get; } = null;
+
+        [Option(LongName = "include-shared-projects",
+        ShortName = "isp",
+        Description = "If set, shared projects (.shproj) will be included in the analysis. By default, shared projects are excluded.")]
+        public bool IncludeSharedProjects { get; } = false;
 
         [Option(LongName = "target-framework",
             ShortName = "f",
@@ -305,9 +311,11 @@ namespace NuGetUtility
             var encounteredExceptions = new List<Exception>();
             var result = new List<ProjectWithReferencedPackages>();
             exceptions = encounteredExceptions;
-            foreach (string project in projects)
-            {
 
+            IEnumerable<string> filteredProjects = ProjectFilterer.Instance.FilterProjects(projects, IncludeSharedProjects);
+
+            foreach (string project in filteredProjects)
+            {
                 try
                 {
                     IEnumerable<PackageIdentity> installedPackages = reader.GetInstalledPackages(project, IncludeTransitive, TargetFramework);

--- a/src/NuGetUtility/ProjectFiltering/ProjectFilterer.cs
+++ b/src/NuGetUtility/ProjectFiltering/ProjectFilterer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGetUtility.ProjectFiltering
+{
+    public class ProjectFilterer
+    {
+        /// <summary>
+        /// A singleton instance of this class.
+        /// </summary>
+        public static ProjectFilterer Instance { get; } = new ProjectFilterer();
+
+        /// <summary>
+        /// Filters a collection of project paths based on inclusion rules.
+        /// </summary>
+        /// <param name="projects">Collection of project paths to filter</param>
+        /// <param name="includeSharedProjects">Whether to include .shproj files</param>
+        /// <returns>Filtered collection of project paths</returns>
+        public IEnumerable<string> FilterProjects(IEnumerable<string> projects, bool includeSharedProjects)
+        {
+            return includeSharedProjects ? projects : projects.Where(p => !IsSharedProject(p));
+        }
+
+        /// <summary>
+        /// Determines if a project is a shared project based on file extension.
+        /// </summary>
+        /// <param name="projectPath">Path to the project file</param>
+        /// <returns>True if the project is a shared project, otherwise false</returns>
+        public bool IsSharedProject(string projectPath)
+        {
+            return projectPath.EndsWith(".shproj", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/NuGetUtility/ProjectFiltering/ProjectFilterer.cs
+++ b/src/NuGetUtility/ProjectFiltering/ProjectFilterer.cs
@@ -8,10 +8,6 @@ namespace NuGetUtility.ProjectFiltering
 {
     public class ProjectFilterer
     {
-        /// <summary>
-        /// A singleton instance of this class.
-        /// </summary>
-        public static ProjectFilterer Instance { get; } = new ProjectFilterer();
 
         /// <summary>
         /// Filters a collection of project paths based on inclusion rules.
@@ -29,7 +25,7 @@ namespace NuGetUtility.ProjectFiltering
         /// </summary>
         /// <param name="projectPath">Path to the project file</param>
         /// <returns>True if the project is a shared project, otherwise false</returns>
-        public bool IsSharedProject(string projectPath)
+        private bool IsSharedProject(string projectPath)
         {
             return projectPath.EndsWith(".shproj", StringComparison.OrdinalIgnoreCase);
         }

--- a/tests/NuGetUtility.Test/ProjectFiltering/ProjectFiltererTest.cs
+++ b/tests/NuGetUtility.Test/ProjectFiltering/ProjectFiltererTest.cs
@@ -34,7 +34,7 @@ namespace NuGetUtility.Test.ProjectFiltering
 
             string[] result = _filterer.FilterProjects(projects, true).ToArray();
 
-            Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result.Count, Is.EqualTo(4));
             Assert.That(result, Does.Contain("one.csproj"));
             Assert.That(result, Does.Contain("two.shproj"));
             Assert.That(result, Does.Contain("three.csproj"));

--- a/tests/NuGetUtility.Test/ProjectFiltering/ProjectFiltererTest.cs
+++ b/tests/NuGetUtility.Test/ProjectFiltering/ProjectFiltererTest.cs
@@ -1,0 +1,60 @@
+﻿using NuGetUtility.ProjectFiltering;
+
+namespace NuGetUtility.Test.ProjectFiltering
+{
+    [TestFixture]
+    class ProjectFiltererTest
+    {
+        private ProjectFilterer _filterer = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _filterer = new ProjectFilterer();
+        }
+
+        [TestCase("test.shproj", true)]
+        [TestCase("test.SHPROJ", true)]
+        [TestCase("test.csproj", false)]
+        [TestCase("test.vbproj", false)]
+        public void IsSharedProject_DetectsProjectTypeCorrectly(string projectPath, bool expectedResult)
+        {
+            bool result = _filterer.IsSharedProject(projectPath);
+
+            Assert.That(result, Is.EqualTo(expectedResult));
+        }
+
+        [Test]
+        public void FilterProjects_ExcludesSharedProjects_WhenIncludeSharedProjectsIsFalse()
+        {
+            var projects = new[] { "one.csproj", "two.shproj", "three.csproj" };
+
+            var result = _filterer.FilterProjects(projects, false).ToArray();
+
+            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result, Does.Contain("one.csproj"));
+            Assert.That(result, Does.Contain("three.csproj"));
+            Assert.That(result, Does.Not.Contain("two.shproj"));
+        }
+
+        [Test]
+        public void FilterProjects_IncludesAllProjects_WhenIncludeSharedProjectsIsTrue()
+        {
+            var projects = new[] { "one.csproj", "two.shproj", "three.csproj" };
+
+            var result = _filterer.FilterProjects(projects, true).ToArray();
+
+            Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result, Does.Contain("one.csproj"));
+            Assert.That(result, Does.Contain("two.shproj"));
+            Assert.That(result, Does.Contain("three.csproj"));
+        }
+
+        [Test]
+        public void Instance_Exists() {
+            var instance = ProjectFilterer.Instance;
+
+            Assert.That(instance, Is.Not.Null);
+        }
+    }
+}

--- a/tests/NuGetUtility.Test/ProjectFiltering/ProjectFiltererTest.cs
+++ b/tests/NuGetUtility.Test/ProjectFiltering/ProjectFiltererTest.cs
@@ -16,9 +16,9 @@ namespace NuGetUtility.Test.ProjectFiltering
         [Test]
         public void FilterProjects_ExcludesSharedProjects_WhenIncludeSharedProjectsIsFalse()
         {
-            var projects = new[] { "one.csproj", "two.shproj", "three.csproj", "four.SHPROJ" };
+            string[] projects = new[] { "one.csproj", "two.shproj", "three.csproj", "four.SHPROJ" };
 
-            var result = _filterer.FilterProjects(projects, false).ToArray();
+            string[] result = _filterer.FilterProjects(projects, false).ToArray();
 
             Assert.That(result.Count, Is.EqualTo(2));
             Assert.That(result, Does.Contain("one.csproj"));
@@ -30,9 +30,9 @@ namespace NuGetUtility.Test.ProjectFiltering
         [Test]
         public void FilterProjects_IncludesAllProjects_WhenIncludeSharedProjectsIsTrue()
         {
-            var projects = new[] { "one.csproj", "two.shproj", "three.csproj", "four.SHPROJ" };
+            string[] projects = new[] { "one.csproj", "two.shproj", "three.csproj", "four.SHPROJ" };
 
-            var result = _filterer.FilterProjects(projects, true).ToArray();
+            string[] result = _filterer.FilterProjects(projects, true).ToArray();
 
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Does.Contain("one.csproj"));

--- a/tests/NuGetUtility.Test/ProjectFiltering/ProjectFiltererTest.cs
+++ b/tests/NuGetUtility.Test/ProjectFiltering/ProjectFiltererTest.cs
@@ -13,21 +13,10 @@ namespace NuGetUtility.Test.ProjectFiltering
             _filterer = new ProjectFilterer();
         }
 
-        [TestCase("test.shproj", true)]
-        [TestCase("test.SHPROJ", true)]
-        [TestCase("test.csproj", false)]
-        [TestCase("test.vbproj", false)]
-        public void IsSharedProject_DetectsProjectTypeCorrectly(string projectPath, bool expectedResult)
-        {
-            bool result = _filterer.IsSharedProject(projectPath);
-
-            Assert.That(result, Is.EqualTo(expectedResult));
-        }
-
         [Test]
         public void FilterProjects_ExcludesSharedProjects_WhenIncludeSharedProjectsIsFalse()
         {
-            var projects = new[] { "one.csproj", "two.shproj", "three.csproj" };
+            var projects = new[] { "one.csproj", "two.shproj", "three.csproj", "four.SHPROJ" };
 
             var result = _filterer.FilterProjects(projects, false).ToArray();
 
@@ -35,12 +24,13 @@ namespace NuGetUtility.Test.ProjectFiltering
             Assert.That(result, Does.Contain("one.csproj"));
             Assert.That(result, Does.Contain("three.csproj"));
             Assert.That(result, Does.Not.Contain("two.shproj"));
+            Assert.That(result, Does.Not.Contain("four.SHPROJ"));
         }
 
         [Test]
         public void FilterProjects_IncludesAllProjects_WhenIncludeSharedProjectsIsTrue()
         {
-            var projects = new[] { "one.csproj", "two.shproj", "three.csproj" };
+            var projects = new[] { "one.csproj", "two.shproj", "three.csproj", "four.SHPROJ" };
 
             var result = _filterer.FilterProjects(projects, true).ToArray();
 
@@ -48,13 +38,6 @@ namespace NuGetUtility.Test.ProjectFiltering
             Assert.That(result, Does.Contain("one.csproj"));
             Assert.That(result, Does.Contain("two.shproj"));
             Assert.That(result, Does.Contain("three.csproj"));
-        }
-
-        [Test]
-        public void Instance_Exists() {
-            var instance = ProjectFilterer.Instance;
-
-            Assert.That(instance, Is.Not.Null);
         }
     }
 }


### PR DESCRIPTION
Added functionality to filter shared VS projects by default. Additionally, you can disable this behavior by utilizing the `include-shared-projects` / `lsp` option.

Closes #168 