### PR TITLE
Prioritize LicenseUrl over LicenseMetadata.

### DIFF
--- a/src/NuGetUtility/LicenseValidator/LicenseValidator.cs
+++ b/src/NuGetUtility/LicenseValidator/LicenseValidator.cs
@@ -44,13 +44,14 @@ namespace NuGetUtility.LicenseValidator
                         info.PackageInfo,
                         LicenseInformationOrigin.Ignored);
                 }
-                else if (info.PackageInfo.LicenseMetadata != null)
-                {
-                    await ValidateLicenseByMetadataAsync(info.PackageInfo, info.Context, result, token);
-                }
+                // LicenseMetadata exists in all cases when using --override-package-information
                 else if (info.PackageInfo.LicenseUrl != null)
                 {
                     await ValidateLicenseByUrl(info.PackageInfo, info.Context, result, token);
+                }
+                else if (info.PackageInfo.LicenseMetadata != null)
+                {
+                    await ValidateLicenseByMetadataAsync(info.PackageInfo, info.Context, result, token);
                 }
                 else
                 {

--- a/tests/NuGetUtility.Test/LicenseValidator/LicenseValidatorTest.cs
+++ b/tests/NuGetUtility.Test/LicenseValidator/LicenseValidatorTest.cs
@@ -80,10 +80,10 @@ namespace NuGetUtility.Test.LicenseValidator
         }
         private IPackageMetadata SetupPackageWithCopyright(string packageId,
             INuGetVersion packageVersion,
-            string copyrigth)
+            string copyright)
         {
             IPackageMetadata packageInfo = SetupPackage(packageId, packageVersion);
-            packageInfo.Copyright.Returns(copyrigth);
+            packageInfo.Copyright.Returns(copyright);
             return packageInfo;
         }
         private IPackageMetadata SetupPackageWithAuthors(string packageId,


### PR DESCRIPTION
This covers a case where --override-package-information is used to override a LicenseUrl for custom paths. Usage of this argument results in LicenseMetadata always existing which caused LicenseUrl to be ignored in all cases, independent of the JSON file contents.