### PR TITLE
enable reproducible builds in CI for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Publish the application binaries (.net472)
         run: msbuild ./src/NuGetLicenseFramework/NuGetLicenseFramework.csproj /t:Publish /p:configuration=Release /p:PublishDir=${{ steps.artifacts_path.outputs.path }}/net472 /p:Version=${{ steps.version.outputs.full_without_prefix }} /p:ContinuousIntegrationBuild=true
       - name: Create nuget package
-        run: dotnet pack ./src/NuGetLicenseCore/NuGetLicenseCore.csproj -c Release --no-build -o ${{ steps.artifacts_path.outputs.path }} -p:Version=${{ steps.version.outputs.full_without_prefix }}
+        run: dotnet pack ./src/NuGetLicenseCore/NuGetLicenseCore.csproj -c Release --no-build -o ${{ steps.artifacts_path.outputs.path }} -p:Version=${{ steps.version.outputs.full_without_prefix }} -p:ContinuousIntegrationBuild=true
 
       - name: Zip artifacts
         uses: thedoctor0/zip-release@0.7.6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled CI build mode during packaging and publishing to ensure consistent compilation and packaging behavior across all release builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->