### PR TITLE
Cache already downloaded items in this run by keeping the download ur…

### DIFF
--- a/src/NuGetLicense/Program.cs
+++ b/src/NuGetLicense/Program.cs
@@ -14,7 +14,6 @@ using NuGetLicense.Output;
 using NuGetLicense.Output.Json;
 using NuGetLicense.Output.Table;
 using NuGetUtility;
-using NuGetUtility.Extension;
 using NuGetUtility.Extensions;
 using NuGetUtility.PackageInformationReader;
 using NuGetUtility.ProjectFiltering;

--- a/src/NuGetUtility/Extensions/AsyncEnumerableExtension.cs
+++ b/src/NuGetUtility/Extensions/AsyncEnumerableExtension.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the projects contributors.
 // The license conditions are provided in the LICENSE file located in the project root
 
-namespace NuGetUtility.Extension
+namespace NuGetUtility.Extensions
 {
     public static class AsyncEnumerableExtension
     {


### PR DESCRIPTION
…l around. This prevents downloading the same license more than once in one run

fixes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated redundant file downloads through deduplication logic, improving download efficiency.

* **Chores**
  * Removed unused library imports.
  * Reorganized internal namespace structure for improved code organization.
  * Enhanced concurrency protection in file download operations to safely handle simultaneous requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->