### PR TITLE
update tests that were only running on .net 9

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -62,7 +62,6 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: | 
-            9.0.x
             10.0.x
          
       - name: restore
@@ -80,7 +79,6 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: | 
-            9.0.x
             10.0.x
       
       - uses: browser-actions/setup-chrome@v2.1.0

--- a/tests/FileLicenseMatcher.Test/FileLicenseMatcher.Test.csproj
+++ b/tests/FileLicenseMatcher.Test/FileLicenseMatcher.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/NuGetUtility.UrlToLicenseMapping.Test/NuGetUtility.UrlToLicenseMapping.Test.csproj
+++ b/tests/NuGetUtility.UrlToLicenseMapping.Test/NuGetUtility.UrlToLicenseMapping.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test projects to target .NET 10.0 instead of .NET 9.0
  * Updated build workflow to support .NET 8.0.x and 10.0.x, removing .NET 9.0.x support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->