### PR TITLE
Fix project glob handling to support just filename filtering

### DIFF
--- a/src/NuGetLicense/LicenseValidationOrchestrator.cs
+++ b/src/NuGetLicense/LicenseValidationOrchestrator.cs
@@ -70,7 +70,7 @@ namespace NuGetLicense
                 ignoredPackagesArray);
 
             string[] excludedProjectsArray = _optionsParser.GetExcludedProjects(options.ExcludedProjects);
-            IEnumerable<string> projects = (await inputFiles.SelectManyAsync(projectCollector.GetProjectsAsync)).Where(p => !Array.Exists(excludedProjectsArray, ignored => p.Like(ignored)));
+            string[] projects = (await inputFiles.SelectManyAsync(projectCollector.GetProjectsAsync)).Where(p => excludedProjectsArray.All(m =>  !p.Like(m) && !_fileSystem.Path.GetFileName(p).Like(m))).ToArray();
             IEnumerable<ProjectWithReferencedPackages> packagesForProject = GetPackagesPerProject(projects, projectReader, options.IncludeTransitive, options.TargetFramework, options.IncludeSharedProjects, out IReadOnlyCollection<Exception> projectReaderExceptions);
             IAsyncEnumerable<ReferencedPackageWithContext> downloadedLicenseInformation =
                 packagesForProject.SelectMany(p => GetPackageInformations(p, overridePackageInformationArray, cancellationToken));


### PR DESCRIPTION
Hi again @sensslen,

Did another round of testing now that I've the source-code locally to test, and it seems that in 4.0.6 release, passing multiple patterns is failing:

````bash
nuget-license -i .\Mosaik.slnx -o JsonPretty -fo .\licenses.json --exclude-projects-matching "*Mosaik.Testing.*;*.pyproj"
>> fails with pyproj-related error
````

While passing them separately seems to work (in the sense that they don't fail due to the filtered project anymore):

```bash
nuget-license -i .\Mosaik.slnx -o JsonPretty -fo .\licenses.json --exclude-projects-matching "*Mosaik.Testing.*"
>> fails with pyproj-related error
```

```bash
nuget-license -i .\Mosaik.slnx -o JsonPretty -fo .\licenses.json --exclude-projects-matching "*.pyproj"`
>> fails with Mosaik.Testing-related error
```

In the latest preview version, passing multiple patterns work fine:

````bash
dotnet tool update --global nuget-license --version 4.0.7-beta.3
Tool 'nuget-license' was successfully updated from version '4.0.6' to version '4.0.7-beta.3'.

nuget-license -i .\Mosaik.slnx -o JsonPretty -fo .\licenses.json --exclude-projects-matching "*Mosaik.Testing.*;*.pyproj"

>> licenses.json file generates correctly
````

So my guess is that the previous SystemCommandLine parsing was not correctly handling the array (probably the target property should have been a `string[]`), but the [move to a new package](https://github.com/sensslen/nuget-license/commit/b2a7524c4e86dbfaced06f1ddb761f74e88aafb9) handles this fine. 

While reviewing it, I noticed that the glob-like matching is not handling only file-name matching, which is a bit surprising. This PR adds a second branch to the check that will also try to match the pattern against the file-name separatelly.

This way, it is also fine to pass a pattern such as `Project.Name*`, and have that match as one would expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined project exclusion logic to apply stricter pattern matching criteria, improving filtering accuracy by validating against both full paths and file names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->