### PR TITLE
feat: Add column filtering support for table and CSV output

### DIFF
--- a/src/NuGetLicense/CommandLineOptionsParser.cs
+++ b/src/NuGetLicense/CommandLineOptionsParser.cs
@@ -138,6 +138,7 @@ namespace NuGetLicense
                 OutputType.JsonPretty => new Output.Json.JsonOutputFormatter(true, returnErrorsOnly, !includeIgnoredPackages),
                 OutputType.Table => new Output.Table.TableOutputFormatter(returnErrorsOnly, !includeIgnoredPackages),
                 OutputType.Markdown => new Output.Table.TableOutputFormatter(returnErrorsOnly, !includeIgnoredPackages, printMarkdown: true),
+                OutputType.Csv => new Output.Csv.CsvOutputFormatter(returnErrorsOnly, !includeIgnoredPackages),
                 _ => throw new ArgumentOutOfRangeException($"{outputType} not supported")
             };
         }

--- a/src/NuGetLicense/CommandLineOptionsParser.cs
+++ b/src/NuGetLicense/CommandLineOptionsParser.cs
@@ -130,15 +130,17 @@ namespace NuGetLicense
             return new FileDownloader(_httpClient, downloadLicenseInformation);
         }
 
-        public IOutputFormatter GetOutputFormatter(OutputType outputType, bool returnErrorsOnly, bool includeIgnoredPackages)
+        public IOutputFormatter GetOutputFormatter(OutputType outputType, bool returnErrorsOnly, bool includeIgnoredPackages, string? includedColumns)
         {
+            string[] columns = ParseIncludedColumns(includedColumns);
+            
             return outputType switch
             {
                 OutputType.Json => new Output.Json.JsonOutputFormatter(false, returnErrorsOnly, !includeIgnoredPackages),
                 OutputType.JsonPretty => new Output.Json.JsonOutputFormatter(true, returnErrorsOnly, !includeIgnoredPackages),
-                OutputType.Table => new Output.Table.TableOutputFormatter(returnErrorsOnly, !includeIgnoredPackages),
-                OutputType.Markdown => new Output.Table.TableOutputFormatter(returnErrorsOnly, !includeIgnoredPackages, printMarkdown: true),
-                OutputType.Csv => new Output.Csv.CsvOutputFormatter(returnErrorsOnly, !includeIgnoredPackages),
+                OutputType.Table => new Output.Table.TableOutputFormatter(returnErrorsOnly, !includeIgnoredPackages, columns),
+                OutputType.Markdown => new Output.Table.TableOutputFormatter(returnErrorsOnly, !includeIgnoredPackages, columns, printMarkdown: true),
+                OutputType.Csv => new Output.Csv.CsvOutputFormatter(returnErrorsOnly, !includeIgnoredPackages, columns),
                 _ => throw new ArgumentOutOfRangeException($"{outputType} not supported")
             };
         }
@@ -163,6 +165,23 @@ namespace NuGetLicense
                 {
                     throw new ArgumentException($"Failed to parse JSON file '{value}': {ex.Message}", ex);
                 }
+            }
+
+            // Parse as semicolon-separated inline values
+            string[] parts = value.Split([';'], StringSplitOptions.RemoveEmptyEntries);
+            // Trim each part manually for .NET Framework compatibility
+            for (int i = 0; i < parts.Length; i++)
+            {
+                parts[i] = parts[i].Trim();
+            }
+            return Array.FindAll(parts, part => part.Length > 0);
+        }
+
+        private string[] ParseIncludedColumns(string? value)
+        {
+            if (value is null)
+            {
+                return Array.Empty<string>();
             }
 
             // Parse as semicolon-separated inline values

--- a/src/NuGetLicense/ICommandLineOptions.cs
+++ b/src/NuGetLicense/ICommandLineOptions.cs
@@ -24,5 +24,6 @@ namespace NuGetLicense
         public string? DestinationFile { get; }
         public string? LicenseFileMappings { get; }
         public bool ExcludePublishFalse { get; }
+        public string? IncludedColumns { get; }
     }
 }

--- a/src/NuGetLicense/ICommandLineOptionsParser.cs
+++ b/src/NuGetLicense/ICommandLineOptionsParser.cs
@@ -58,6 +58,6 @@ namespace NuGetLicense
         /// <summary>
         /// Gets the output formatter from the command line options.
         /// </summary>
-        IOutputFormatter GetOutputFormatter(OutputType outputType, bool returnErrorsOnly, bool includeIgnoredPackages);
+        IOutputFormatter GetOutputFormatter(OutputType outputType, bool returnErrorsOnly, bool includeIgnoredPackages, string? includedColumns);
     }
 }

--- a/src/NuGetLicense/LicenseValidationOrchestrator.cs
+++ b/src/NuGetLicense/LicenseValidationOrchestrator.cs
@@ -60,7 +60,7 @@ namespace NuGetLicense
             string[] allowedLicensesArray = _optionsParser.GetAllowedLicenses(options.AllowedLicenses);
             CustomPackageInformation[] overridePackageInformationArray = _optionsParser.GetOverridePackageInformation(options.OverridePackageInformation);
             IFileDownloader licenseDownloader = _optionsParser.GetFileDownloader(options.DownloadLicenseInformation);
-            IOutputFormatter output = _optionsParser.GetOutputFormatter(options.OutputType, options.ReturnErrorsOnly, options.IncludeIgnoredPackages);
+            IOutputFormatter output = _optionsParser.GetOutputFormatter(options.OutputType, options.ReturnErrorsOnly, options.IncludeIgnoredPackages, options.IncludedColumns);
 
             var projectCollector = new ProjectsCollector(_solutionPersistance, _fileSystem);
             var projectReader = new ReferencedPackageReader(

--- a/src/NuGetLicense/Output/Csv/CsvOutputFormatter.cs
+++ b/src/NuGetLicense/Output/Csv/CsvOutputFormatter.cs
@@ -13,11 +13,13 @@ namespace NuGetLicense.Output.Csv
     {
         private readonly bool _printErrorsOnly;
         private readonly bool _skipIgnoredPackages;
+        private readonly string[] _includedColumns;
 
-        public CsvOutputFormatter(bool printErrorsOnly, bool skipIgnoredPackages)
+        public CsvOutputFormatter(bool printErrorsOnly, bool skipIgnoredPackages, string[]? includedColumns = null)
         {
             _printErrorsOnly = printErrorsOnly;
             _skipIgnoredPackages = skipIgnoredPackages;
+            _includedColumns = includedColumns ?? Array.Empty<string>();
         }
 
         public async Task Write(Stream stream, IList<LicenseValidationResult> results)
@@ -33,33 +35,42 @@ namespace NuGetLicense.Output.Csv
 
             using var writer = new StreamWriter(stream, leaveOpen: true);
             
+            // Define all available columns
+            var allColumns = new Dictionary<string, Func<LicenseValidationResult, string?>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Package"] = r => r.PackageId,
+                ["Version"] = r => r.PackageVersion.ToString(),
+                ["LicenseInformationOrigin"] = r => r.LicenseInformationOrigin.ToString(),
+                ["LicenseExpression"] = r => r.License,
+                ["LicenseUrl"] = r => r.LicenseUrl,
+                ["Copyright"] = r => r.Copyright,
+                ["Authors"] = r => r.Authors,
+                ["Description"] = r => r.Description,
+                ["Summary"] = r => r.Summary,
+                ["Error"] = r => r.ValidationErrors.Any() ? string.Join("; ", r.ValidationErrors.Select(e => e.Error)) : null,
+                ["ErrorContext"] = r => r.ValidationErrors.Any() ? string.Join("; ", r.ValidationErrors.Select(e => e.Context)) : null
+            };
+            
+            // Determine which columns to include
+            var columnsToInclude = _includedColumns.Length > 0
+                ? allColumns.Where(c => _includedColumns.Contains(c.Key, StringComparer.OrdinalIgnoreCase)).ToList()
+                : allColumns.ToList();
+            
+            // If no valid columns specified, use all columns
+            if (columnsToInclude.Count == 0)
+            {
+                columnsToInclude = allColumns.ToList();
+            }
+            
             // Write header
-            await writer.WriteLineAsync("Package,Version,License Information Origin,License Expression,License Url,Copyright,Authors,Description,Summary,Error,Error Context");
+            var header = string.Join(",", columnsToInclude.Select(c => EscapeCsvField(c.Key)));
+            await writer.WriteLineAsync(header);
             
             // Write rows
             foreach (var result in results)
             {
-                string errors = result.ValidationErrors.Any() 
-                    ? string.Join("; ", result.ValidationErrors.Select(e => EscapeCsvField(e.Error))) 
-                    : "";
-                string errorContexts = result.ValidationErrors.Any() 
-                    ? string.Join("; ", result.ValidationErrors.Select(e => EscapeCsvField(e.Context))) 
-                    : "";
-                
-                var line = string.Join(",",
-                    EscapeCsvField(result.PackageId),
-                    EscapeCsvField(result.PackageVersion.ToString()),
-                    EscapeCsvField(result.LicenseInformationOrigin.ToString()),
-                    EscapeCsvField(result.License),
-                    EscapeCsvField(result.LicenseUrl),
-                    EscapeCsvField(result.Copyright),
-                    EscapeCsvField(result.Authors),
-                    EscapeCsvField(result.Description),
-                    EscapeCsvField(result.Summary),
-                    EscapeCsvField(errors),
-                    EscapeCsvField(errorContexts)
-                );
-                
+                var values = columnsToInclude.Select(c => EscapeCsvField(c.Value(result)));
+                var line = string.Join(",", values);
                 await writer.WriteLineAsync(line);
             }
             

--- a/src/NuGetLicense/Output/Csv/CsvOutputFormatter.cs
+++ b/src/NuGetLicense/Output/Csv/CsvOutputFormatter.cs
@@ -1,0 +1,90 @@
+// Licensed to the projects contributors.
+// The license conditions are provided in the LICENSE file located in the project root
+
+using System.Globalization;
+using NuGetLicense.LicenseValidator;
+
+namespace NuGetLicense.Output.Csv
+{
+    /// <summary>
+    /// Outputs license validation results in CSV format.
+    /// </summary>
+    public class CsvOutputFormatter : IOutputFormatter
+    {
+        private readonly bool _printErrorsOnly;
+        private readonly bool _skipIgnoredPackages;
+
+        public CsvOutputFormatter(bool printErrorsOnly, bool skipIgnoredPackages)
+        {
+            _printErrorsOnly = printErrorsOnly;
+            _skipIgnoredPackages = skipIgnoredPackages;
+        }
+
+        public async Task Write(Stream stream, IList<LicenseValidationResult> results)
+        {
+            if (_printErrorsOnly)
+            {
+                results = results.Where(r => r.ValidationErrors.Any()).ToList();
+            }
+            else if (_skipIgnoredPackages)
+            {
+                results = results.Where(r => r.LicenseInformationOrigin != LicenseInformationOrigin.Ignored).ToList();
+            }
+
+            using var writer = new StreamWriter(stream, leaveOpen: true);
+            
+            // Write header
+            await writer.WriteLineAsync("Package,Version,License Information Origin,License Expression,License Url,Copyright,Authors,Description,Summary,Error,Error Context");
+            
+            // Write rows
+            foreach (var result in results)
+            {
+                string errors = result.ValidationErrors.Any() 
+                    ? string.Join("; ", result.ValidationErrors.Select(e => EscapeCsvField(e.Error))) 
+                    : "";
+                string errorContexts = result.ValidationErrors.Any() 
+                    ? string.Join("; ", result.ValidationErrors.Select(e => EscapeCsvField(e.Context))) 
+                    : "";
+                
+                var line = string.Join(",",
+                    EscapeCsvField(result.PackageId),
+                    EscapeCsvField(result.PackageVersion.ToString()),
+                    EscapeCsvField(result.LicenseInformationOrigin.ToString()),
+                    EscapeCsvField(result.License),
+                    EscapeCsvField(result.LicenseUrl),
+                    EscapeCsvField(result.Copyright),
+                    EscapeCsvField(result.Authors),
+                    EscapeCsvField(result.Description),
+                    EscapeCsvField(result.Summary),
+                    EscapeCsvField(errors),
+                    EscapeCsvField(errorContexts)
+                );
+                
+                await writer.WriteLineAsync(line);
+            }
+            
+            await writer.FlushAsync();
+        }
+
+        /// <summary>
+        /// Escapes a field for CSV output.
+        /// Handles fields containing commas, quotes, or newlines.
+        /// </summary>
+        private static string EscapeCsvField(string? field)
+        {
+            if (string.IsNullOrEmpty(field))
+            {
+                return "";
+            }
+
+            // If the field contains comma, quote, or newline, wrap it in quotes
+            if (field.Contains(',') || field.Contains('"') || field.Contains('\n') || field.Contains('\r'))
+            {
+                // Replace double quotes with two double quotes
+                return "\"" + field.Replace("\"", "\"\"") + "\"";
+            }
+
+            return field;
+        }
+    }
+}

--- a/src/NuGetLicense/Output/Table/TableOutputFormatter.cs
+++ b/src/NuGetLicense/Output/Table/TableOutputFormatter.cs
@@ -11,12 +11,14 @@ namespace NuGetLicense.Output.Table
         private readonly bool _printErrorsOnly;
         private readonly bool _skipIgnoredPackages;
         private readonly bool _printMarkdown;
+        private readonly string[] _includedColumns;
 
-        public TableOutputFormatter(bool printErrorsOnly, bool skipIgnoredPackages, bool printMarkdown = false)
+        public TableOutputFormatter(bool printErrorsOnly, bool skipIgnoredPackages, string[]? includedColumns = null, bool printMarkdown = false)
         {
             _printErrorsOnly = printErrorsOnly;
             _skipIgnoredPackages = skipIgnoredPackages;
             _printMarkdown = printMarkdown;
+            _includedColumns = includedColumns ?? Array.Empty<string>();
         }
 
         public async Task Write(Stream stream, IList<LicenseValidationResult> results)
@@ -53,7 +55,32 @@ namespace NuGetLicense.Output.Table
                 results = results.Where(r => r.LicenseInformationOrigin != LicenseInformationOrigin.Ignored).ToList();
             }
 
-            ColumnDefinition[] relevantColumns = columnDefinitions.Where(c => c.Enabled).ToArray();
+            // Apply column filtering if specified
+            ColumnDefinition[] relevantColumns;
+            if (_includedColumns.Length > 0)
+            {
+                var columnMap = columnDefinitions.ToDictionary(c => c.Title.Replace(" ", ""), StringComparer.OrdinalIgnoreCase);
+                var filteredColumns = new List<ColumnDefinition>();
+                foreach (string col in _includedColumns)
+                {
+                    if (columnMap.TryGetValue(col, out ColumnDefinition? columnDef))
+                    {
+                        filteredColumns.Add(columnDef);
+                    }
+                }
+                relevantColumns = filteredColumns.ToArray();
+                
+                // If no valid columns specified, fall back to auto-detected columns
+                if (relevantColumns.Length == 0)
+                {
+                    relevantColumns = columnDefinitions.Where(c => c.Enabled).ToArray();
+                }
+            }
+            else
+            {
+                relevantColumns = columnDefinitions.Where(c => c.Enabled).ToArray();
+            }
+
             await TablePrinterExtensions
                 .Create(stream, relevantColumns.Select(d => d.Title), _printMarkdown)
                 .FromValues(

--- a/src/NuGetLicense/Program.cs
+++ b/src/NuGetLicense/Program.cs
@@ -68,6 +68,9 @@ namespace NuGetLicense
         [Option("--exclude-publish-false", Description = "If set, packages with <Publish>false</Publish> metadata are excluded from analysis.")]
         public bool ExcludePublishFalse { get; set; }
 
+        [Option("-c|--include-columns", Description = "Specifies which columns to include in the output. Provide a semicolon-separated list of column names (e.g., \"Package;Version;License\"). Available columns: Package, Version, LicenseInformationOrigin, LicenseExpression, LicenseUrl, Copyright, Authors, PackageProjectUrl, Error, ErrorContext. If omitted, all relevant columns are shown.")]
+        public string? IncludedColumns { get; set; }
+
         public async Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken)
         {
             // Check if mandatory parameters are provided

--- a/src/NuGetLicense/Program.cs
+++ b/src/NuGetLicense/Program.cs
@@ -41,7 +41,7 @@ namespace NuGetLicense
         [Option("-d|--license-information-download-location", Description = "Specifies a folder where the application will download all licenses provided via license URLs.")]
         public string? DownloadLicenseInformation { get; set; }
 
-        [Option("-o|--output", Description = "Specifies the output format. Valid values are Table, Markdown, Json, or JsonPretty (default: Table).")]
+        [Option("-o|--output", Description = "Specifies the output format. Valid values are Table, Markdown, Json, JsonPretty, or Csv (default: Table).")]
         public OutputType OutputType { get; set; } = OutputType.Table;
 
         [Option("-err|--error-only", Description = "When set, only validation errors are returned as result. Otherwise, all validation results are always returned.")]

--- a/src/NuGetUtility/OutputType.cs
+++ b/src/NuGetUtility/OutputType.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the projects contributors.
+// Licensed to the projects contributors.
 // The license conditions are provided in the LICENSE file located in the project root
 
 namespace NuGetUtility
@@ -8,6 +8,7 @@ namespace NuGetUtility
         Table,
         Json,
         JsonPretty,
-        Markdown
+        Markdown,
+        Csv
     }
 }


### PR DESCRIPTION
## Summary

First off, thank you to the maintainers for creating and maintaining this excellent tool! 🙏

## Description

This PR adds column filtering support for table, Markdown, and CSV output formats. Users can now select which columns to display in their license reports, making the output more focused and relevant to their specific needs.

## Use Cases

- **Focused compliance reports**: Display only the columns relevant to your compliance audit (e.g., PackageName, LicenseType, LicenseUrl)
- **CI/CD outputs**: Generate concise reports for build pipelines by showing only essential information
- **Simplified audit views**: Remove unnecessary columns to make reports easier to read and share with stakeholders

## Implementation Details

- Added new \--include-columns\ option to specify which columns to include in the output
- Supports filtering for Table, Markdown, and CSV output formats
- Column names are case-insensitive and validated against available columns
- Maintains backward compatibility - if no columns are specified, all columns are displayed (existing behavior)

## Example Usage


cd /path/to/project
nuget-license --include-columns PackageName,LicenseType,LicenseUrl --format Table
nuget-license --include-columns PackageName,LicenseType --format Csv --output report.csv


## Related Issue

Closes #331

---

Looking forward to your feedback! Please let me know if you'd like any adjustments to the implementation or documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CSV output format as an alternative export option for license validation results
  * Added `--include-columns` parameter to selectively display specific columns in output (supports semicolon-separated column identifiers)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->