### PR TITLE
Update to re-entrant version od the SPDX expression parser

### DIFF
--- a/src/NuGetLicense/LicenseValidator/LicenseValidator.cs
+++ b/src/NuGetLicense/LicenseValidator/LicenseValidator.cs
@@ -16,7 +16,6 @@ namespace NuGetLicense.LicenseValidator
 {
     public class LicenseValidator
     {
-        private static readonly SemaphoreSlim s_spdxParserSemaphore = new SemaphoreSlim(1, 1);
         private readonly IEnumerable<string> _allowedLicenses;
         private readonly IFileDownloader _fileDownloader;
         private readonly IFileLicenseMatcher _fileLicenseMatcher;
@@ -142,7 +141,7 @@ namespace NuGetLicense.LicenseValidator
                 case LicenseType.Overwrite:
                     {
                         string licenseId = info.LicenseMetadata!.License;
-                        SpdxExpression? licenseExpression = await ParseSpdxExpressionAsync(licenseId, token);
+                        SpdxExpression? licenseExpression = ParseSpdxExpression(licenseId);
                         if (IsValidLicenseExpression(licenseExpression))
                         {
                             await DownloadLicenseAsync(GetLicenseUrl(licenseId), info.Identity, context, token);
@@ -175,7 +174,7 @@ namespace NuGetLicense.LicenseValidator
                             break;
                         }
 
-                        SpdxExpression? licenseExpression = await ParseSpdxExpressionAsync(matchedLicense, token);
+                        SpdxExpression? licenseExpression = ParseSpdxExpression(matchedLicense);
                         if (IsValidLicenseExpression(licenseExpression))
                         {
                             await StoreLicenseAsync(info.LicenseMetadata.License, info.Identity, token);
@@ -227,7 +226,7 @@ namespace NuGetLicense.LicenseValidator
 
             if (_licenseMapping.TryGetValue(info.LicenseUrl, out string? licenseId))
             {
-                SpdxExpression? licenseExpression = await ParseSpdxExpressionAsync(licenseId, token);
+                SpdxExpression? licenseExpression = ParseSpdxExpression(licenseId);
 
                 if (IsValidLicenseExpression(licenseExpression))
                 {
@@ -327,18 +326,7 @@ namespace NuGetLicense.LicenseValidator
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, $"This conversion method only supports the {nameof(LicenseType.Overwrite)} and {nameof(LicenseType.Expression)} types for conversion")
         };
 
-        private static async Task<SpdxExpression?> ParseSpdxExpressionAsync(string expression, CancellationToken token)
-        {
-            await s_spdxParserSemaphore.WaitAsync(token);
-            try
-            {
-                return SpdxExpressionParser.Parse(expression, _ => true, _ => true);
-            }
-            finally
-            {
-                s_spdxParserSemaphore.Release();
-            }
-        }
+        private static SpdxExpression? ParseSpdxExpression(string expression) => SpdxExpressionParser.Parse(expression, _ => true, _ => true);
 
         private sealed record LicenseNameAndVersion(string LicenseName, INuGetVersion Version);
     }

--- a/src/NuGetLicense/NuGetLicense.csproj
+++ b/src/NuGetLicense/NuGetLicense.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.IO.Hashing" Version="10.0.5" />
-    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
+    <PackageReference Include="System.IO.Hashing" Version="10.0.6" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.6" />
     <PackageReference Include="PolySharp" Version="1.15.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/NuGetUtility/Extensions/StringExtensions.cs
+++ b/src/NuGetUtility/Extensions/StringExtensions.cs
@@ -18,7 +18,7 @@ namespace NuGetUtility.Extensions
             return new Regex(
                 $"^{Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".")}$",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline,
-                TimeSpan.FromMilliseconds(100)
+                TimeSpan.FromMilliseconds(1000)
             ).IsMatch(str);
         }
 

--- a/src/NuGetUtility/NuGetUtility.csproj
+++ b/src/NuGetUtility/NuGetUtility.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
     <PackageReference Include="NuGet.ProjectModel" Version="7.3.1" />
     <PackageReference Include="NuGet.Frameworks" Version="7.3.1" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Tethys.SPDX.ExpressionParser" Version="2.1.3" />
+    <PackageReference Include="Tethys.SPDX.ExpressionParser" Version="2.2.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions" Version="22.1.1" />
   </ItemGroup>
 
@@ -39,8 +39,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.IO.Hashing" Version="10.0.5" />
-    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
+    <PackageReference Include="System.IO.Hashing" Version="10.0.6" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.6" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" Version="18.*" />
     <PackageReference Include="PolySharp" Version="1.15.*">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/FileLicenseMatcher.Test/FileLicenseMatcher.Test.csproj
+++ b/tests/FileLicenseMatcher.Test/FileLicenseMatcher.Test.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="TUnit" Version="1.32.0" />
+    <PackageReference Include="TUnit" Version="1.33.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/NuGetLicense.Test/NuGetLicense.Test.csproj
+++ b/tests/NuGetLicense.Test/NuGetLicense.Test.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="TUnit" Version="1.32.0" />
+    <PackageReference Include="TUnit" Version="1.33.0" />
     <PackageReference Include="Verify.Tunit" Version="31.15.0" />
     <PackageReference Include="Verify.ParametersHashing" Version="1.0.0" />
   </ItemGroup>

--- a/tests/NuGetUtility.Test/NuGetUtility.Test.csproj
+++ b/tests/NuGetUtility.Test/NuGetUtility.Test.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageReference Include="TUnit" Version="1.32.0" />
+    <PackageReference Include="TUnit" Version="1.33.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/NuGetUtility.UrlToLicenseMapping.Test/NuGetUtility.UrlToLicenseMapping.Test.csproj
+++ b/tests/NuGetUtility.UrlToLicenseMapping.Test/NuGetUtility.UrlToLicenseMapping.Test.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="TUnit" Version="1.32.0" />
+    <PackageReference Include="TUnit" Version="1.33.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/targets/VersionRangesProject/VersionRangesProject.csproj
+++ b/tests/targets/VersionRangesProject/VersionRangesProject.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[10.0.5]" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[10.0.6]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies: System.IO.Hashing, System.Collections.Immutable, and Microsoft.Extensions.Logging.Abstractions to patch versions.
  * Bumped Tethys.SPDX.ExpressionParser to version 2.2.0.
  * Updated test framework dependencies (TUnit to 1.33.0).

* **Refactor**
  * Simplified SPDX license expression parsing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->