### PR TITLE
Augment NuGet metadata with package overrides

### DIFF
--- a/docs/override-package-json.md
+++ b/docs/override-package-json.md
@@ -1,10 +1,14 @@
 # Override Package Information JSON File Format (`--override-package-information`)
 
-The override package information JSON file is used with the `-override` or `--override-package-information` option to supply custom license and metadata for specific packages. This is useful when a package's license metadata is missing, incorrect, or needs to be supplemented.
+The override package information JSON file is used with the `-override` or `--override-package-information` option to supply custom license and metadata for specific packages. This is useful when a package's license metadata is missing, incorrect, or needs to be supplemented without duplicating all metadata from the NuGet package.
+
+When an override entry matches a package, the tool still reads the package metadata from the local NuGet package cache or configured NuGet repositories. The override entry augments that metadata: the required `License` field replaces the package license information, and any optional fields supplied by the override replace the corresponding package metadata fields. Optional fields omitted from the override keep the values found in the NuGet package metadata.
 
 ## Format
 
 The file must contain a JSON array of objects, each specifying a package and its information.
+
+Each object must identify the package and provide the license to use for that package. Optional fields may be included when the NuGet package metadata is missing, incorrect, or should be replaced.
 
 ```json
 [
@@ -43,6 +47,7 @@ The file must contain a JSON array of objects, each specifying a package and its
 
 **Notes:**
 - `Id`, `Version`, and `License` are required. All other fields are optional.
+- Optional fields only replace NuGet package metadata when they are present in the override entry. If they are omitted, the downloaded package metadata is used.
 - `Version` must match the NuGet version format.
 - `LicenseUrl` should be a valid URL string.
 
@@ -56,6 +61,11 @@ The file must contain a JSON array of objects, each specifying a package and its
     "License": "BSD-3-Clause",
     "Title": "Example Package",
     "ProjectUrl": "https://example.com"
+  },
+  {
+    "Id": "Minimal.Example.Package",
+    "Version": "1.0.0",
+    "License": "MIT"
   }
 ]
 ```

--- a/docs/override-package-json.md
+++ b/docs/override-package-json.md
@@ -47,7 +47,6 @@ Each object must identify the package and provide the license to use for that pa
 
 **Notes:**
 - `Id`, `Version`, and `License` are required. All other fields are optional.
-- Optional fields only replace NuGet package metadata when they are present in the override entry. If they are omitted, the downloaded package metadata is used.
 - `Version` must match the NuGet version format.
 - `LicenseUrl` should be a valid URL string.
 

--- a/src/NuGetUtility/PackageInformationReader/OverridePackageMetadata.cs
+++ b/src/NuGetUtility/PackageInformationReader/OverridePackageMetadata.cs
@@ -1,0 +1,38 @@
+// Licensed to the project contributors.
+// The license conditions are provided in the LICENSE file located in the project root
+
+using NuGetUtility.Wrapper.NuGetWrapper.Packaging;
+using NuGetUtility.Wrapper.NuGetWrapper.Packaging.Core;
+
+namespace NuGetUtility.PackageInformationReader
+{
+    internal sealed class OverridePackageMetadata : IPackageMetadata
+    {
+        private readonly IPackageMetadata _metadata;
+        private readonly CustomPackageInformation _customPackageInformation;
+
+        public OverridePackageMetadata(IPackageMetadata metadata, CustomPackageInformation customPackageInformation)
+        {
+            _metadata = metadata;
+            _customPackageInformation = customPackageInformation;
+        }
+
+        public PackageIdentity Identity => _metadata.Identity;
+
+        public string? Title => _customPackageInformation.Title ?? _metadata.Title;
+
+        public Uri? LicenseUrl => _customPackageInformation.LicenseUrl ?? _metadata.LicenseUrl;
+
+        public string? ProjectUrl => _customPackageInformation.ProjectUrl ?? _metadata.ProjectUrl;
+
+        public string? Description => _customPackageInformation.Description ?? _metadata.Description;
+
+        public string? Summary => _customPackageInformation.Summary ?? _metadata.Summary;
+
+        public string? Copyright => _customPackageInformation.Copyright ?? _metadata.Copyright;
+
+        public string? Authors => _customPackageInformation.Authors ?? _metadata.Authors;
+
+        public LicenseMetadata? LicenseMetadata => new(LicenseType.Overwrite, _customPackageInformation.License);
+    }
+}

--- a/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
+++ b/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
@@ -20,22 +20,25 @@ namespace NuGetUtility.PackageInformationReader
         {
             foreach (PackageIdentity package in projectWithReferencedPackages.ReferencedPackages)
             {
-                PackageSearchResult result = TryGetPackageInfoFromCustomInformation(package);
+                CustomPackageInformation? customInformation = TryGetPackageInfoFromCustomInformation(package);
+                PackageSearchResult result = TryGetPackageInformationFromGlobalPackageFolder(package);
                 if (result.Success)
                 {
-                    yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project, result.Metadata!);
-                    continue;
-                }
-                result = TryGetPackageInformationFromGlobalPackageFolder(package);
-                if (result.Success)
-                {
-                    yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project, result.Metadata!);
+                    yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
+                                                                  ApplyCustomInformation(result.Metadata!, customInformation));
                     continue;
                 }
                 result = await TryGetPackageInformationFromRepositories(_repositories, package, cancellation);
                 if (result.Success)
                 {
-                    yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project, result.Metadata!);
+                    yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
+                                                                  ApplyCustomInformation(result.Metadata!, customInformation));
+                    continue;
+                }
+                if (customInformation is not null)
+                {
+                    yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
+                                                                  new PackageMetadata(package, LicenseType.Overwrite, customInformation));
                     continue;
                 }
                 // simply return input - validation will fail later, as the required fields are missing
@@ -85,16 +88,21 @@ namespace NuGetUtility.PackageInformationReader
             return new PackageSearchResult();
         }
 
-        private PackageSearchResult TryGetPackageInfoFromCustomInformation(PackageIdentity package)
+        private CustomPackageInformation? TryGetPackageInfoFromCustomInformation(PackageIdentity package)
         {
             CustomPackageInformation? resolvedCustomInformation = customPackageInformation.FirstOrDefault(info =>
-                info.Id.Equals(package.Id) && info.Version.Equals(package.Version));
-            if (resolvedCustomInformation is null)
+                string.Equals(info.Id, package.Id, StringComparison.OrdinalIgnoreCase) && info.Version.Equals(package.Version));
+            return resolvedCustomInformation;
+        }
+
+        private static IPackageMetadata ApplyCustomInformation(IPackageMetadata metadata, CustomPackageInformation? customInformation)
+        {
+            if (customInformation is null)
             {
-                return new PackageSearchResult();
+                return metadata;
             }
 
-            return new PackageSearchResult(new PackageMetadata(package, LicenseType.Overwrite, resolvedCustomInformation));
+            return new OverridePackageMetadata(metadata, customInformation);
         }
 
         private static async Task<IPackageMetadataResource?> TryGetPackageMetadataResource(ISourceRepository repository, CancellationToken token)

--- a/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
+++ b/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
@@ -12,6 +12,7 @@ using NuGetUtility.Wrapper.NuGetWrapper.Packaging;
 using NuGetUtility.Wrapper.NuGetWrapper.Packaging.Core;
 using NuGetUtility.Wrapper.NuGetWrapper.Protocol;
 using NuGetUtility.Wrapper.NuGetWrapper.Protocol.Core.Types;
+using NuGetUtility.Wrapper.NuGetWrapper.Versioning;
 
 namespace NuGetUtility.Test.PackageInformationReader
 {
@@ -56,7 +57,7 @@ namespace NuGetUtility.Test.PackageInformationReader
         private readonly IGlobalPackagesFolderUtility _globalPackagesFolderUtility;
 
         [Test]
-        public async Task GetPackageInfo_Should_PreferProvidedCustomInformation()
+        public async Task GetPackageInfo_Should_ReturnCustomInformation_IfPackageMetadataIsNotFound()
         {
             List<CustomPackageInformation> customPackageInformation = _fixture.CreateMany<CustomPackageInformation>().ToList();
             var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, customPackageInformation);
@@ -68,6 +69,244 @@ namespace NuGetUtility.Test.PackageInformationReader
                 .ToArray();
 
             await CheckResult(result, project, customPackageInformation, LicenseType.Overwrite);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_AugmentLocalPackageCacheWithCustomLicenseInformation()
+        {
+            CustomPackageInformation packageMetadata = _fixture.Create<CustomPackageInformation>();
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            CustomPackageInformation customPackageInformation = new(packageMetadata.Id, packageMetadata.Version, _fixture.Create<string>());
+            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
+                                                                                              _globalPackagesFolderUtility,
+                                                                                              [customPackageInformation]);
+            IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
+            _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
+
+            ReferencedPackageWithContext result = await GetSinglePackageInfo(localUut, identity);
+
+            await AssertMergedMetadata(result.PackageInfo, packageMetadata, customPackageInformation.License);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.Type).IsEqualTo(LicenseType.Overwrite);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_FallBackToAllFetchedOptionalFields_WhenCustomInformationOnlyProvidesLicense()
+        {
+            CustomPackageInformation packageMetadata = CreatePackageInformationWithOptionalFields();
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            CustomPackageInformation customPackageInformation = new(packageMetadata.Id, packageMetadata.Version, _fixture.Create<string>());
+            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
+                                                                                              _globalPackagesFolderUtility,
+                                                                                              [customPackageInformation]);
+            IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
+            _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
+
+            ReferencedPackageWithContext result = await GetSinglePackageInfo(localUut, identity);
+
+            await AssertMergedMetadata(result.PackageInfo, packageMetadata, customPackageInformation.License);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.Type).IsEqualTo(LicenseType.Overwrite);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_AugmentRepositoryPackageMetadataWithCustomLicenseInformation()
+        {
+            CustomPackageInformation packageMetadata = _fixture.Create<CustomPackageInformation>();
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            CustomPackageInformation customPackageInformation = new(packageMetadata.Id, packageMetadata.Version, _fixture.Create<string>());
+            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
+                                                                                              _globalPackagesFolderUtility,
+                                                                                              [customPackageInformation]);
+            IPackageMetadataResource metadataResource = Substitute.For<IPackageMetadataResource>();
+            _repositories[0].GetPackageMetadataResourceAsync(default).Returns(_ => Task.FromResult<IPackageMetadataResource?>(metadataResource));
+            metadataResource.TryGetMetadataAsync(identity, Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult<IPackageMetadata?>(CreatePackageMetadata(packageMetadata, LicenseType.Expression)));
+
+            ReferencedPackageWithContext result = await GetSinglePackageInfo(localUut, identity);
+
+            await AssertMergedMetadata(result.PackageInfo, packageMetadata, customPackageInformation.License);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.Type).IsEqualTo(LicenseType.Overwrite);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_PreferCustomOptionalFieldsOverFetchedPackageMetadata()
+        {
+            CustomPackageInformation packageMetadata = CreatePackageInformationWithOptionalFields();
+            CustomPackageInformation customPackageInformation = CreatePackageInformationWithOptionalFields(packageMetadata.Id, packageMetadata.Version);
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
+                                                                                              _globalPackagesFolderUtility,
+                                                                                              [customPackageInformation]);
+            IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
+            _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
+
+            ReferencedPackageWithContext result = await GetSinglePackageInfo(localUut, identity);
+
+            await AssertPackageInformation(result.PackageInfo, customPackageInformation);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.Type).IsEqualTo(LicenseType.Overwrite);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_MergeCustomAndFetchedOptionalFieldsIndividually()
+        {
+            CustomPackageInformation packageMetadata = CreatePackageInformationWithOptionalFields();
+            CustomPackageInformation customPackageInformation = new(packageMetadata.Id,
+                                                                     packageMetadata.Version,
+                                                                     _fixture.Create<string>(),
+                                                                     Authors: _fixture.Create<string>(),
+                                                                     Title: null,
+                                                                     ProjectUrl: _fixture.Create<string>(),
+                                                                     Summary: null,
+                                                                     Description: _fixture.Create<string>(),
+                                                                     LicenseUrl: null);
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
+                                                                                              _globalPackagesFolderUtility,
+                                                                                              [customPackageInformation]);
+            IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
+            _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
+
+            ReferencedPackageWithContext result = await GetSinglePackageInfo(localUut, identity);
+
+            await Assert.That(result.PackageInfo.LicenseMetadata!.License).IsEqualTo(customPackageInformation.License);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.Type).IsEqualTo(LicenseType.Overwrite);
+            await Assert.That(result.PackageInfo.Copyright).IsEqualTo(packageMetadata.Copyright);
+            await Assert.That(result.PackageInfo.Authors).IsEqualTo(customPackageInformation.Authors);
+            await Assert.That(result.PackageInfo.Title).IsEqualTo(packageMetadata.Title);
+            await Assert.That(result.PackageInfo.ProjectUrl).IsEqualTo(customPackageInformation.ProjectUrl);
+            await Assert.That(result.PackageInfo.Summary).IsEqualTo(packageMetadata.Summary);
+            await Assert.That(result.PackageInfo.Description).IsEqualTo(customPackageInformation.Description);
+            await Assert.That(result.PackageInfo.LicenseUrl).IsEqualTo(packageMetadata.LicenseUrl);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_TreatEmptyCustomOptionalStringsAsOverrides()
+        {
+            CustomPackageInformation packageMetadata = CreatePackageInformationWithOptionalFields();
+            CustomPackageInformation customPackageInformation = new(packageMetadata.Id,
+                                                                     packageMetadata.Version,
+                                                                     _fixture.Create<string>(),
+                                                                     Copyright: string.Empty,
+                                                                     Authors: string.Empty,
+                                                                     Title: string.Empty,
+                                                                     ProjectUrl: string.Empty,
+                                                                     Summary: string.Empty,
+                                                                     Description: string.Empty);
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
+                                                                                              _globalPackagesFolderUtility,
+                                                                                              [customPackageInformation]);
+            IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
+            _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
+
+            ReferencedPackageWithContext result = await GetSinglePackageInfo(localUut, identity);
+
+            await Assert.That(result.PackageInfo.Copyright).IsEqualTo(string.Empty);
+            await Assert.That(result.PackageInfo.Authors).IsEqualTo(string.Empty);
+            await Assert.That(result.PackageInfo.Title).IsEqualTo(string.Empty);
+            await Assert.That(result.PackageInfo.ProjectUrl).IsEqualTo(string.Empty);
+            await Assert.That(result.PackageInfo.Summary).IsEqualTo(string.Empty);
+            await Assert.That(result.PackageInfo.Description).IsEqualTo(string.Empty);
+            await Assert.That(result.PackageInfo.LicenseUrl).IsEqualTo(packageMetadata.LicenseUrl);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.License).IsEqualTo(customPackageInformation.License);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.Type).IsEqualTo(LicenseType.Overwrite);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_ApplyCustomLicenseInformationAfterRepositoryFileLicenseIsDownloaded()
+        {
+            CustomPackageInformation packageMetadata = _fixture.Create<CustomPackageInformation>();
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            CustomPackageInformation customPackageInformation = new(packageMetadata.Id, packageMetadata.Version, _fixture.Create<string>());
+            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
+                                                                                              _globalPackagesFolderUtility,
+                                                                                              [customPackageInformation]);
+            IPackageMetadataResource metadataResource = Substitute.For<IPackageMetadataResource>();
+            IFindPackageByIdResource archiveReader = Substitute.For<IFindPackageByIdResource>();
+            IPackageDownloader packageDownloader = Substitute.For<IPackageDownloader>();
+            _repositories[0].GetPackageMetadataResourceAsync(default).Returns(_ => Task.FromResult<IPackageMetadataResource?>(metadataResource));
+            _repositories[0].GetPackageArchiveReaderAsync(default).Returns(_ => Task.FromResult<IFindPackageByIdResource?>(archiveReader));
+            metadataResource.TryGetMetadataAsync(identity, Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult<IPackageMetadata?>(CreatePackageMetadata(packageMetadata, LicenseType.File, "LICENSE.txt")));
+            archiveReader.TryGetPackageDownloader(identity, Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult<IPackageDownloader?>(packageDownloader));
+            packageDownloader.ReadAsync("LICENSE.txt", Arg.Any<CancellationToken>()).Returns(_ => Task.FromResult(_fixture.Create<string>()));
+
+            ReferencedPackageWithContext result = await GetSinglePackageInfo(localUut, identity);
+
+            await AssertMergedMetadata(result.PackageInfo, packageMetadata, customPackageInformation.License);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.Type).IsEqualTo(LicenseType.Overwrite);
+        }
+
+        private async Task<ReferencedPackageWithContext> GetSinglePackageInfo(
+            NuGetUtility.PackageInformationReader.PackageInformationReader packageInformationReader,
+            PackageIdentity packageIdentity)
+        {
+            string project = _fixture.Create<string>();
+            var packageSearchRequest = new ProjectWithReferencedPackages(project, [packageIdentity]);
+            ReferencedPackageWithContext[] result = (await packageInformationReader.GetPackageInfo(packageSearchRequest, CancellationToken.None).Synchronize())
+                .ToArray();
+
+            await Assert.That(result.Length).IsEqualTo(1);
+            await Assert.That(result[0].Context).IsEqualTo(project);
+            return result[0];
+        }
+
+        private static IPackageMetadata CreatePackageMetadata(CustomPackageInformation packageInformation, LicenseType licenseType, string? license = null)
+        {
+            var identity = new PackageIdentity(packageInformation.Id, packageInformation.Version);
+            IPackageMetadata metadata = Substitute.For<IPackageMetadata>();
+            metadata.Identity.Returns(identity);
+            metadata.Copyright.Returns(packageInformation.Copyright);
+            metadata.Authors.Returns(packageInformation.Authors);
+            metadata.Title.Returns(packageInformation.Title);
+            metadata.ProjectUrl.Returns(packageInformation.ProjectUrl);
+            metadata.Summary.Returns(packageInformation.Summary);
+            metadata.Description.Returns(packageInformation.Description);
+            metadata.LicenseUrl.Returns(packageInformation.LicenseUrl);
+            metadata.LicenseMetadata.Returns(new LicenseMetadata(licenseType, license ?? packageInformation.License));
+            return metadata;
+        }
+
+        private CustomPackageInformation CreatePackageInformationWithOptionalFields(string? id = null, INuGetVersion? version = null)
+        {
+            return new CustomPackageInformation(id ?? _fixture.Create<string>(),
+                                                version ?? _fixture.Create<INuGetVersion>(),
+                                                _fixture.Create<string>(),
+                                                _fixture.Create<string>(),
+                                                _fixture.Create<string>(),
+                                                _fixture.Create<string>(),
+                                                _fixture.Create<string>(),
+                                                _fixture.Create<string>(),
+                                                _fixture.Create<string>(),
+                                                _fixture.Create<Uri>());
+        }
+
+        private static async Task AssertMergedMetadata(IPackageMetadata result, CustomPackageInformation packageMetadata, string expectedLicense)
+        {
+            await Assert.That(result.Identity.Id).IsEqualTo(packageMetadata.Id);
+            await Assert.That(result.Identity.Version).IsEqualTo(packageMetadata.Version);
+            await Assert.That(result.LicenseMetadata!.License).IsEqualTo(expectedLicense);
+            await Assert.That(result.Copyright).IsEqualTo(packageMetadata.Copyright);
+            await Assert.That(result.Authors).IsEqualTo(packageMetadata.Authors);
+            await Assert.That(result.Title).IsEqualTo(packageMetadata.Title);
+            await Assert.That(result.ProjectUrl).IsEqualTo(packageMetadata.ProjectUrl);
+            await Assert.That(result.Summary).IsEqualTo(packageMetadata.Summary);
+            await Assert.That(result.Description).IsEqualTo(packageMetadata.Description);
+            await Assert.That(result.LicenseUrl).IsEqualTo(packageMetadata.LicenseUrl);
+        }
+
+        private static async Task AssertPackageInformation(IPackageMetadata result, CustomPackageInformation expected)
+        {
+            await Assert.That(result.Identity.Id).IsEqualTo(expected.Id);
+            await Assert.That(result.Identity.Version).IsEqualTo(expected.Version);
+            await Assert.That(result.LicenseMetadata!.License).IsEqualTo(expected.License);
+            await Assert.That(result.Copyright).IsEqualTo(expected.Copyright);
+            await Assert.That(result.Authors).IsEqualTo(expected.Authors);
+            await Assert.That(result.Title).IsEqualTo(expected.Title);
+            await Assert.That(result.ProjectUrl).IsEqualTo(expected.ProjectUrl);
+            await Assert.That(result.Summary).IsEqualTo(expected.Summary);
+            await Assert.That(result.Description).IsEqualTo(expected.Description);
+            await Assert.That(result.LicenseUrl).IsEqualTo(expected.LicenseUrl);
         }
 
         private async Task<(string Project, ReferencedPackageWithContext[] Result)> PerformSearch(
@@ -110,17 +349,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             IEnumerable<PackageIdentity> searchedPackages = searchedPackagesAsPackageInformation.Select(info =>
             {
                 var identity = new PackageIdentity(info.Id, info.Version);
-                IPackageMetadata mockedInfo = Substitute.For<IPackageMetadata>();
-                mockedInfo.Identity.Returns(identity);
-                mockedInfo.Copyright.Returns(info.Copyright);
-                mockedInfo.Authors.Returns(info.Authors);
-                mockedInfo.Title.Returns(info.Title);
-                mockedInfo.ProjectUrl.Returns(info.ProjectUrl);
-                mockedInfo.Summary.Returns(info.Summary);
-                mockedInfo.Description.Returns(info.Description);
-                mockedInfo.LicenseUrl.Returns(info.LicenseUrl);
-                mockedInfo.LicenseMetadata.Returns(new LicenseMetadata(LicenseType.Expression, info.License));
-                mockedInfo.LicenseUrl.Returns(info.LicenseUrl);
+                IPackageMetadata mockedInfo = CreatePackageMetadata(info, LicenseType.Expression);
                 _globalPackagesFolderUtility.GetPackage(identity).Returns(mockedInfo);
 
                 return identity;
@@ -140,17 +369,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             foreach (CustomPackageInformation package in packages)
             {
                 IPackageMetadataResource metadataReturningProperInformation = packageMetadataResources.Shuffle(6435).First();
-                IPackageMetadata resultingInfo = Substitute.For<IPackageMetadata>();
-                resultingInfo.Identity.Returns(new PackageIdentity(package.Id, package.Version));
-                resultingInfo.LicenseMetadata.Returns(new LicenseMetadata(LicenseType.Expression, package.License));
-                resultingInfo.LicenseUrl.Returns(package.LicenseUrl);
-                resultingInfo.Copyright.Returns(package.Copyright);
-                resultingInfo.Authors.Returns(package.Authors);
-                resultingInfo.Title.Returns(package.Title);
-                resultingInfo.Summary.Returns(package.Summary);
-                resultingInfo.Description.Returns(package.Description);
-                resultingInfo.ProjectUrl.Returns(package.ProjectUrl);
-                resultingInfo.LicenseUrl.Returns(package.LicenseUrl);
+                IPackageMetadata resultingInfo = CreatePackageMetadata(package, LicenseType.Expression);
 
                 metadataReturningProperInformation.TryGetMetadataAsync(new PackageIdentity(package.Id, package.Version), Arg.Any<CancellationToken>()).
                     Returns(_ => Task.FromResult<IPackageMetadata?>(resultingInfo));

--- a/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
+++ b/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
@@ -90,6 +90,25 @@ namespace NuGetUtility.Test.PackageInformationReader
         }
 
         [Test]
+        public async Task GetPackageInfo_Should_MatchCustomInformationPackageIdIgnoringCase()
+        {
+            CustomPackageInformation packageMetadata = CreatePackageInformationWithOptionalFields();
+            var identity = new PackageIdentity(packageMetadata.Id.ToUpperInvariant(), packageMetadata.Version);
+            CustomPackageInformation customPackageInformation = new(packageMetadata.Id.ToLowerInvariant(), packageMetadata.Version, _fixture.Create<string>());
+            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
+                                                                                              _globalPackagesFolderUtility,
+                                                                                              [customPackageInformation]);
+            IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata with { Id = identity.Id }, LicenseType.Expression);
+            _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
+
+            ReferencedPackageWithContext result = await GetSinglePackageInfo(localUut, identity);
+
+            await Assert.That(result.PackageInfo.Identity.Id).IsEqualTo(identity.Id);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.License).IsEqualTo(customPackageInformation.License);
+            await Assert.That(result.PackageInfo.LicenseMetadata!.Type).IsEqualTo(LicenseType.Overwrite);
+        }
+
+        [Test]
         public async Task GetPackageInfo_Should_FallBackToAllFetchedOptionalFields_WhenCustomInformationOnlyProvidesLicense()
         {
             CustomPackageInformation packageMetadata = CreatePackageInformationWithOptionalFields();


### PR DESCRIPTION
# PR Description

## Summary

This change updates `--override-package-information` so override entries augment the metadata read from the actual NuGet package instead of replacing that metadata entirely.

Previously, when a package matched an override entry, the package information reader returned metadata built only from the override JSON. That meant optional fields such as authors, title, project URL, summary, description, copyright, and license URL were lost unless users copied them into the override file.

With this change, the normal metadata lookup still runs first against the local NuGet package cache and configured NuGet repositories. If an override entry exists for the package, the override license is applied on top of the fetched metadata, and any optional override fields that are present replace the corresponding NuGet metadata fields. Optional fields omitted from the override continue to use the values from the NuGet package metadata.

## Changes

- Apply package override information after normal NuGet metadata lookup.
- Add an `OverridePackageMetadata` wrapper to merge fetched metadata with override metadata.
- Keep `License` from override information as the final license source and mark it as `LicenseType.Overwrite`.
- Preserve fetched NuGet metadata for optional fields when those fields are omitted from the override file.
- Keep the existing override-only fallback for packages that cannot be found in the local cache or repositories.
- Validate override JSON entries so `Id`, `Version`, and `License` are required.
- Update override package documentation to describe the augmentation and fallback behavior.

## Merge Behavior

For a matching override entry:

- `Id` and `Version` identify the package to augment.
- `License` is required and replaces the license information read from NuGet metadata.
- `Copyright`, `Authors`, `Title`, `ProjectUrl`, `Summary`, `Description`, and `LicenseUrl` are optional.
- Optional fields supplied in the override file replace the corresponding NuGet metadata fields.
- Optional fields omitted from the override file fall back to the metadata read from the NuGet package.
- Empty optional strings are treated as explicit override values; only `null`/omitted values fall back.

## Tests

Added and updated tests covering:

- Override-only fallback when package metadata cannot be found.
- Local cache metadata augmented with override license information.
- Repository metadata augmented with override license information.
- Optional fields falling back to fetched NuGet metadata.
- Optional override fields taking precedence over fetched metadata.
- Field-by-field mixed merge behavior.
- Empty optional strings being treated as explicit override values.
- Repository file-license metadata still being resolved before override license information is applied.
- Parser validation for missing `Id`, `Version`, and `License`.

## Verification

Ran targeted tests successfully:

```powershell
dotnet test tests\NuGetUtility.Test\NuGetUtility.Test.csproj --framework net8.0 --treenode-filter "/*/*/PackageInformationReaderTest/*"
dotnet test tests\NuGetLicense.Test\NuGetLicense.Test.csproj --framework net8.0 --treenode-filter "/*/*/*/GetOverridePackageInformation*"
```

Also ran `git diff --check` successfully.

A full `NuGetUtility.Test` run still has unrelated existing failures in `ReferencedPackagesReaderIntegrationTest`, where several multi-target package-list assertions return an empty collection. The targeted package override tests pass.

this closes #548 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how override entries replace or merge with package metadata and added a minimal example.

* **Improvements**
  * Consistent application of custom package metadata (including license) across local cache and remote sources; optional fields merge when present.

* **Tests**
  * Added tests covering custom metadata merging, case-insensitive ID matching, empty-string overrides, and license override scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->