### PR TITLE
feat: implement exclusion of private assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Supports transitive dependencies, custom mappings, and overrides
 - Flexible output: table or JSON (pretty/minified)
 - Exclude or ignore specific packages or projects
+- Exclude development-only packages (marked with `<PrivateAssets>all</PrivateAssets>` or `<Publish>false</Publish>`)
 - Works with .NET Core, .NET Framework, and native C++ projects
 
 ## Project Structure
@@ -69,6 +70,7 @@ nuget-license [options]
 | `-include-ignored`, `--include-ignored-packages` | When set, ignored packages are included in the output. |
 | `-exclude-projects`, `--exclude-projects-matching <FILE\|LIST>` | Specifies projects to exclude from analysis. You can provide either a JSON file (see [docs/exclude-projects-json.md](docs/exclude-projects-json.md)), or a semicolon-separated list (e.g., `"*Test*;Legacy*"`). Wildcards (`*`) are supported. |
 | `--exclude-publish-false` | Excludes packages marked with `<Publish>false</Publish>` metadata in the project file. This also recursively excludes transitive dependencies. A package is only excluded if all paths leading to it originate from a `Publish="false"` reference (consistent with `dotnet publish` behavior). |
+| `--exclude-private-assets` | Excludes packages marked with `<PrivateAssets>all</PrivateAssets>` metadata in the project file (development-only packages). This also recursively excludes transitive dependencies. See [docs/exclude-private-assets.md](docs/exclude-private-assets.md) for more details. |
 | `-isp`, `--include-shared-projects` | Include shared projects (`.shproj`). |
 | `-f`, `--target-framework <TFM>` | Analyze for a specific Target Framework Moniker. |
 | `-fo`, `--file-output <FILE>` | Write output to a file instead of console. |
@@ -163,6 +165,23 @@ See [docs/output-json.md](docs/output-json.md) for detailed information about th
 
 ```ps
 nuget-license -i MyProject.csproj -d licenses/
+```
+
+### Exclude development-only packages
+
+Exclude packages marked with `<Publish>false</Publish>`:
+```ps
+nuget-license -i MyProject.csproj --exclude-publish-false
+```
+
+Exclude packages marked with `<PrivateAssets>all</PrivateAssets>`:
+```ps
+nuget-license -i MyProject.csproj --exclude-private-assets
+```
+
+Exclude both types of development-only packages:
+```ps
+nuget-license -i MyProject.csproj --exclude-publish-false --exclude-private-assets -o JsonPretty
 ```
 
 ### Map license files to license types

--- a/src/NuGetLicense/ICommandLineOptions.cs
+++ b/src/NuGetLicense/ICommandLineOptions.cs
@@ -24,5 +24,6 @@ namespace NuGetLicense
         public string? DestinationFile { get; }
         public string? LicenseFileMappings { get; }
         public bool ExcludePublishFalse { get; }
+        public bool ExcludePrivateAssets { get; }
     }
 }

--- a/src/NuGetLicense/LicenseValidationOrchestrator.cs
+++ b/src/NuGetLicense/LicenseValidationOrchestrator.cs
@@ -62,6 +62,7 @@ namespace NuGetLicense
                                                                                                   options.IncludeTransitive,
                                                                                                   options.TargetFramework,
                                                                                                   options.ExcludePublishFalse,
+                                                                                                  options.ExcludePrivateAssets,
                                                                                                   options.IncludeSharedProjects,
                                                                                                   out IReadOnlyCollection<Exception> projectReaderExceptions);
             IAsyncEnumerable<ReferencedPackageWithContext> downloadedLicenseInformation =
@@ -141,6 +142,7 @@ namespace NuGetLicense
                                                                                                 bool includeTransitive,
                                                                                                 string? targetFramework,
                                                                                                 bool excludePublishFalse,
+                                                                                                bool excludePrivateAssets,
                                                                                                 bool includeSharedProjects,
                                                                                                 out IReadOnlyCollection<Exception> exceptions)
         {
@@ -153,7 +155,7 @@ namespace NuGetLicense
             {
                 try
                 {
-                    IEnumerable<PackageIdentity> installedPackages = reader.GetInstalledPackages(project, includeTransitive, targetFramework, excludePublishFalse);
+                    IEnumerable<PackageIdentity> installedPackages = reader.GetInstalledPackages(project, includeTransitive, targetFramework, excludePublishFalse, excludePrivateAssets);
                     result.Add(new ProjectWithReferencedPackages(project, installedPackages));
                 }
                 catch (Exception e)

--- a/src/NuGetLicense/LicenseValidationOrchestrator.cs
+++ b/src/NuGetLicense/LicenseValidationOrchestrator.cs
@@ -57,13 +57,17 @@ namespace NuGetLicense
 
             string[] excludedProjectsArray = optionsParser.GetExcludedProjects(options.ExcludedProjects);
             IEnumerable<string> projects = (await inputFiles.SelectManyAsync(projectCollector.GetProjectsAsync)).Where(p => !Array.Exists(excludedProjectsArray, p.PathLike));
+            var packageReaderOptions = new PackageReaderOptions
+            {
+                IncludeTransitive = options.IncludeTransitive,
+                TargetFramework = options.TargetFramework,
+                ExcludePublishFalse = options.ExcludePublishFalse,
+                ExcludePrivateAssets = options.ExcludePrivateAssets,
+                IncludeSharedProjects = options.IncludeSharedProjects
+            };
             IEnumerable<ProjectWithReferencedPackages> packagesForProject = GetPackagesPerProject(projects,
                                                                                                   projectReader,
-                                                                                                  options.IncludeTransitive,
-                                                                                                  options.TargetFramework,
-                                                                                                  options.ExcludePublishFalse,
-                                                                                                  options.ExcludePrivateAssets,
-                                                                                                  options.IncludeSharedProjects,
+                                                                                                  packageReaderOptions,
                                                                                                   out IReadOnlyCollection<Exception> projectReaderExceptions);
             IAsyncEnumerable<ReferencedPackageWithContext> downloadedLicenseInformation =
                 packagesForProject.SelectMany(p => GetPackageInformation(p, overridePackageInformationArray, cancellationToken));
@@ -139,11 +143,7 @@ namespace NuGetLicense
 
         private static IReadOnlyCollection<ProjectWithReferencedPackages> GetPackagesPerProject(IEnumerable<string> projects,
                                                                                                 ReferencedPackageReader reader,
-                                                                                                bool includeTransitive,
-                                                                                                string? targetFramework,
-                                                                                                bool excludePublishFalse,
-                                                                                                bool excludePrivateAssets,
-                                                                                                bool includeSharedProjects,
+                                                                                                PackageReaderOptions options,
                                                                                                 out IReadOnlyCollection<Exception> exceptions)
         {
             var encounteredExceptions = new List<Exception>();
@@ -151,11 +151,11 @@ namespace NuGetLicense
             exceptions = encounteredExceptions;
 
             ProjectFilter filter = new();
-            foreach (string project in filter.FilterProjects(projects, includeSharedProjects))
+            foreach (string project in filter.FilterProjects(projects, options.IncludeSharedProjects))
             {
                 try
                 {
-                    IEnumerable<PackageIdentity> installedPackages = reader.GetInstalledPackages(project, includeTransitive, targetFramework, excludePublishFalse, excludePrivateAssets);
+                    IEnumerable<PackageIdentity> installedPackages = reader.GetInstalledPackages(project, options.IncludeTransitive, options.TargetFramework, options.ExcludePublishFalse, options.ExcludePrivateAssets);
                     result.Add(new ProjectWithReferencedPackages(project, installedPackages));
                 }
                 catch (Exception e)

--- a/src/NuGetLicense/PackageReaderOptions.cs
+++ b/src/NuGetLicense/PackageReaderOptions.cs
@@ -1,0 +1,38 @@
+// Licensed to the project contributors.
+// The license conditions are provided in the LICENSE file located in the project root
+
+namespace NuGetLicense
+{
+    /// <summary>
+    /// Options for reading referenced packages from projects.
+    /// </summary>
+    public class PackageReaderOptions
+    {
+        /// <summary>
+        /// True to include transitive dependencies; otherwise, false.
+        /// </summary>
+        public bool IncludeTransitive { get; set; } = false;
+
+        /// <summary>
+        /// Target framework moniker to evaluate. If null, all available target frameworks are evaluated.
+        /// </summary>
+        public string? TargetFramework { get; set; } = null;
+
+        /// <summary>
+        /// True to exclude packages with Publish="false" metadata. When transitive dependencies are included,
+        /// packages reachable only through those excluded roots are also excluded.
+        /// </summary>
+        public bool ExcludePublishFalse { get; set; } = false;
+
+        /// <summary>
+        /// True to exclude packages with PrivateAssets="all" metadata (development-only packages).
+        /// When transitive dependencies are included, packages reachable only through those excluded roots are also excluded.
+        /// </summary>
+        public bool ExcludePrivateAssets { get; set; } = false;
+
+        /// <summary>
+        /// True to include shared projects; otherwise, false.
+        /// </summary>
+        public bool IncludeSharedProjects { get; set; } = false;
+    }
+}

--- a/src/NuGetLicense/Program.cs
+++ b/src/NuGetLicense/Program.cs
@@ -68,6 +68,9 @@ namespace NuGetLicense
         [Option("--exclude-publish-false", Description = "If set, packages with <Publish>false</Publish> metadata are excluded from analysis.")]
         public bool ExcludePublishFalse { get; set; }
 
+        [Option("--exclude-private-assets", Description = "If set, packages with <PrivateAssets>all</PrivateAssets> metadata (development-only packages) are excluded from analysis.")]
+        public bool ExcludePrivateAssets { get; set; }
+
         public async Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken)
         {
             // Check if mandatory parameters are provided

--- a/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
+++ b/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
@@ -364,7 +364,11 @@ namespace NuGetUtility.ReferencedPackagesReader
             foreach (PackageReferenceMetadata packageReference in packageReferences ?? [])
             {
                 if (packageReference.Metadata.TryGetValue("PrivateAssets", out string? value) &&
-                    value != null && value.IndexOf("all", StringComparison.OrdinalIgnoreCase) >= 0)
+                    value != null &&
+                    value.Split(';')
+                        .Select(token => token.Trim())
+                        .Where(token => !string.IsNullOrEmpty(token))
+                        .Any(token => string.Equals(token, "all", StringComparison.OrdinalIgnoreCase)))
                 {
                     excludedPackages.Add(packageReference.PackageName);
                 }

--- a/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
+++ b/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
@@ -30,12 +30,16 @@ namespace NuGetUtility.ReferencedPackagesReader
         /// True to exclude packages with Publish="false" metadata. When transitive dependencies are included,
         /// packages reachable only through those excluded roots are also excluded.
         /// </param>
+        /// <param name="excludePrivateAssets">
+        /// True to exclude packages with PrivateAssets="all" metadata (development-only packages). When transitive dependencies are included,
+        /// packages reachable only through those excluded roots are also excluded.
+        /// </param>
         /// <returns>Resolved package identities from project assets or packages.config.</returns>
-        public IEnumerable<PackageIdentity> GetInstalledPackages(string projectPath, bool includeTransitive, string? targetFramework = null, bool excludePublishFalse = false)
+        public IEnumerable<PackageIdentity> GetInstalledPackages(string projectPath, bool includeTransitive, string? targetFramework = null, bool excludePublishFalse = false, bool excludePrivateAssets = false)
         {
             IProject project = msBuild.GetProject(projectPath);
 
-            if (TryGetInstalledPackagesFromAssetsFile(includeTransitive, project, targetFramework, excludePublishFalse, out IEnumerable<PackageIdentity>? dependencies))
+            if (TryGetInstalledPackagesFromAssetsFile(includeTransitive, project, targetFramework, excludePublishFalse, excludePrivateAssets, out IEnumerable<PackageIdentity>? dependencies))
             {
                 return dependencies;
             }
@@ -52,6 +56,7 @@ namespace NuGetUtility.ReferencedPackagesReader
                                                            IProject project,
                                                            string? targetFramework,
                                                            bool excludePublishFalse,
+                                                           bool excludePrivateAssets,
                                                            [NotNullWhen(true)] out IEnumerable<PackageIdentity>? installedPackages)
         {
             installedPackages = null;
@@ -70,12 +75,14 @@ namespace NuGetUtility.ReferencedPackagesReader
             {
                 HashSet<ILockFileLibrary> targetReferencedLibraries = [.. GetReferencedLibrariesForTarget(includeTransitive, assetsFile, target)];
 
-                if (excludePublishFalse)
+                if (excludePublishFalse || excludePrivateAssets)
                 {
                     HashSet<string> excludedPackages = GetExcludedPackagesForTarget(project,
                                                                                     assetsFile,
                                                                                     target,
                                                                                     includeTransitive,
+                                                                                    excludePublishFalse,
+                                                                                    excludePrivateAssets,
                                                                                     publishExclusionContext);
 
                     targetReferencedLibraries.RemoveWhere(library => excludedPackages.Contains(library.Name));
@@ -112,19 +119,29 @@ namespace NuGetUtility.ReferencedPackagesReader
                                                              ILockFile assetsFile,
                                                              ILockFileTarget target,
                                                              bool includeTransitive,
+                                                             bool excludePublishFalse,
+                                                             bool excludePrivateAssets,
                                                              PublishExclusionContext context)
         {
             string targetFrameworkForPublishMetadata = context.NormalizedRequestedTargetFramework ?? nuGetFrameworkUtility.Normalize(target.TargetFramework);
             string targetFrameworkCacheKey = targetFrameworkForPublishMetadata ?? string.Empty;
 
-            // Remove packages with Publish=false metadata from the evaluated PackageReferences for this target only.
-            if (!context.PublishFalsePackagesByFramework.TryGetValue(targetFrameworkCacheKey, out HashSet<string>? cachedPublishFalsePackages))
+            // Remove packages with Publish=false and PrivateAssets=all metadata from the evaluated PackageReferences for this target only.
+            if (!context.PublishFalsePackagesByFramework.TryGetValue(targetFrameworkCacheKey, out HashSet<string>? cachedExcludedPackages))
             {
-                cachedPublishFalsePackages = GetPackagesExcludedFromPublish(project, targetFrameworkForPublishMetadata);
-                context.PublishFalsePackagesByFramework[targetFrameworkCacheKey] = cachedPublishFalsePackages;
+                cachedExcludedPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                if (excludePublishFalse)
+                {
+                    cachedExcludedPackages.UnionWith(GetPackagesExcludedFromPublish(project, targetFrameworkForPublishMetadata));
+                }
+                if (excludePrivateAssets)
+                {
+                    cachedExcludedPackages.UnionWith(GetPackagesExcludedByPrivateAssets(project, targetFrameworkForPublishMetadata));
+                }
+                context.PublishFalsePackagesByFramework[targetFrameworkCacheKey] = cachedExcludedPackages;
             }
 
-            HashSet<string> excludedPackages = new(cachedPublishFalsePackages, StringComparer.OrdinalIgnoreCase);
+            HashSet<string> excludedPackages = new(cachedExcludedPackages, StringComparer.OrdinalIgnoreCase);
             if (!includeTransitive || !excludedPackages.Any())
             {
                 return excludedPackages;
@@ -328,6 +345,26 @@ namespace NuGetUtility.ReferencedPackagesReader
             {
                 if (packageReference.Metadata.TryGetValue("Publish", out string? value) &&
                     string.Equals(value, "false", StringComparison.OrdinalIgnoreCase))
+                {
+                    excludedPackages.Add(packageReference.PackageName);
+                }
+            }
+
+            return excludedPackages;
+        }
+
+        private static HashSet<string> GetPackagesExcludedByPrivateAssets(IProject project, string? targetFramework)
+        {
+            // PrivateAssets metadata is not available in project.assets.json, so resolve it via MSBuild items.
+            IEnumerable<PackageReferenceMetadata> packageReferences = targetFramework is null
+                ? project.GetPackageReferences()
+                : project.GetPackageReferencesForTarget(targetFramework);
+
+            HashSet<string> excludedPackages = new(StringComparer.OrdinalIgnoreCase);
+            foreach (PackageReferenceMetadata packageReference in packageReferences ?? [])
+            {
+                if (packageReference.Metadata.TryGetValue("PrivateAssets", out string? value) &&
+                    value != null && value.IndexOf("all", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     excludedPackages.Add(packageReference.PackageName);
                 }


### PR DESCRIPTION
Adds the option to exclude private asset packages that are only used during development while building the application.
This also excludes transient dependencies

This should address #552 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI option (--exclude-private-assets) to exclude development-only packages marked with PrivateAssets=all and their transitive dependencies from license analysis.
  * Added an options model to control package reading behavior (transitive, target framework, publish/private-assets exclusions, shared projects).

* **Documentation**
  * Updated README with a dedicated “Exclude development-only packages” section and examples for excluding publish-false, private-assets, and both together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->