### PR TITLE
Use latest version of MSBuild by default

### DIFF
--- a/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
+++ b/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
@@ -33,7 +33,7 @@ namespace NuGetUtility.Wrapper.MsBuildWrapper
         {
             if (!MSBuildLocator.IsRegistered)
             {
-                MSBuildLocator.RegisterInstance(MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(instance => instance.Version));
+                MSBuildLocator.RegisterInstance(MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(instance => instance.Version).First());
             }
         }
 

--- a/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
+++ b/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
@@ -33,7 +33,7 @@ namespace NuGetUtility.Wrapper.MsBuildWrapper
         {
             if (!MSBuildLocator.IsRegistered)
             {
-                MSBuildLocator.RegisterDefaults();
+                MSBuildLocator.RegisterInstance(MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(instance => instance.Version));
             }
         }
 


### PR DESCRIPTION
This would fix #563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MSBuild resolution to explicitly select a Visual Studio MSBuild instance by highest available version, improving reliability when loading projects in environments with multiple Visual Studio installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->