### PR TITLE
Make prerequisites obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ dotnet tool install --global nuget-license
 
 ### NuGetLicenseFramework.exe
 
-Download the latest release from [GitHub Releases](https://github.com/sensslen/nuget-license/releases) and run the executable directly.
+Download the latest release from [GitHub Releases](https://github.com/sensslen/nuget-license/releases) and run the executable directly. Before running it, make sure the [Prerequisites](#prerequisites) are installed.
+
+### Prerequisites
+
+The `NuGetLicenseFramework.exe` variant locates MSBuild through a Visual Studio installation. It therefore requires **Visual Studio** or the standalone **[Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/?q=build+tools)** to be installed. If neither is present, the tool exits with an error stating that no MSBuild instance could be detected.
+
+This is why switching from the `NuGetLicenseCore` dotnet tool to `NuGetLicenseFramework.exe` can produce a *"No instances of MSBuild could be detected"* error: the .NET Framework variant looks for MSBuild via Visual Studio rather than the .NET SDK. For background on how MSBuild is located, see Microsoft's documentation on [MSBuild and Visual Studio version detection](https://learn.microsoft.com/visualstudio/msbuild/updating-an-existing-application).
 
 ## Usage
 

--- a/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
+++ b/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
@@ -39,8 +39,7 @@ namespace NuGetUtility.Wrapper.MsBuildWrapper
                 {
                     throw new MsBuildAbstractionException(
                         "No MSBuild instance could be detected. The .NET Framework variant of this tool requires Visual Studio or the Visual Studio Build Tools to be installed in order to locate MSBuild. " +
-                        "Please install the \"Visual Studio Build Tools\" (https://visualstudio.microsoft.com/downloads/?q=build+tools) or use the .NET Core (dotnet tool) variant instead. " +
-                        "See https://learn.microsoft.com/visualstudio/msbuild/updating-an-existing-application for more information on how MSBuild is detected.");
+                        "Please install the \"Visual Studio Build Tools\" (https://visualstudio.microsoft.com/downloads/?q=build+tools) or use the .NET Core (dotnet tool) variant instead. ");
                 }
 
                 MSBuildLocator.RegisterInstance(instance);

--- a/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
+++ b/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
@@ -33,7 +33,20 @@ namespace NuGetUtility.Wrapper.MsBuildWrapper
         {
             if (!MSBuildLocator.IsRegistered)
             {
-                MSBuildLocator.RegisterInstance(MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(instance => instance.Version).First());
+#if NETFRAMEWORK
+                VisualStudioInstance? instance = MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(i => i.Version).FirstOrDefault();
+                if (instance is null)
+                {
+                    throw new MsBuildAbstractionException(
+                        "No MSBuild instance could be detected. The .NET Framework variant of this tool requires Visual Studio or the Visual Studio Build Tools to be installed in order to locate MSBuild. " +
+                        "Please install the \"Visual Studio Build Tools\" (https://visualstudio.microsoft.com/downloads/?q=build+tools) or use the .NET Core (dotnet tool) variant instead. " +
+                        "See https://learn.microsoft.com/visualstudio/msbuild/updating-an-existing-application for more information on how MSBuild is detected.");
+                }
+
+                MSBuildLocator.RegisterInstance(instance);
+#else
+                MSBuildLocator.RegisterInstance(MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(i => i.Version).First());
+#endif
             }
         }
 


### PR DESCRIPTION
Fixes #573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded installation instructions with a new “Prerequisites” section for the `NuGetLicenseFramework.exe` variant, including environment requirements and notes about MSBuild detection behavior when switching from the .NET tool.
* **Bug Fixes**
  * Improved MSBuild instance discovery behavior on .NET Framework environments, adding clearer failure handling and actionable guidance when no suitable MSBuild instance can be detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->