### PR TITLE
fix: resolve packages from assets fallback folders before remote lookup

### DIFF
--- a/src/NuGetLicense/LicenseValidationOrchestrator.cs
+++ b/src/NuGetLicense/LicenseValidationOrchestrator.cs
@@ -152,8 +152,7 @@ namespace NuGetLicense
             {
                 try
                 {
-                    IEnumerable<PackageIdentity> installedPackages = reader.GetInstalledPackages(project, includeTransitive, targetFramework, excludePublishFalse);
-                    result.Add(new ProjectWithReferencedPackages(project, installedPackages));
+                    result.Add(reader.GetInstalledPackages(project, includeTransitive, targetFramework, excludePublishFalse));
                 }
                 catch (Exception e)
                 {
@@ -172,12 +171,10 @@ namespace NuGetLicense
             var sourceProvider = new PackageSourceProvider(settings);
 
             using var sourceRepositoryProvider = new WrappedSourceRepositoryProvider(new SourceRepositoryProvider(sourceProvider, Repository.Provider.GetCoreV3()));
-            var globalPackagesFolderUtility = new GlobalPackagesFolderUtility(settings);
+            var globalPackagesFolderUtility = new GlobalPackagesFolderUtility(settings, projectWithReferences.PackageFolders);
             var informationReader = new PackageInformationReader(sourceRepositoryProvider, globalPackagesFolderUtility, overridePackageInformation);
 
-            await foreach (ReferencedPackageWithContext package in informationReader.GetPackageInfo(new ProjectWithReferencedPackages(projectWithReferences.Project,
-                                                                                                                                      projectWithReferences.ReferencedPackages),
-                                                                                                    cancellation))
+            await foreach (ReferencedPackageWithContext package in informationReader.GetPackageInfo(projectWithReferences, cancellation))
             {
                 yield return package;
             }

--- a/src/NuGetUtility/PackageInformationReader/ProjectWithReferencedPackages.cs
+++ b/src/NuGetUtility/PackageInformationReader/ProjectWithReferencedPackages.cs
@@ -5,5 +5,12 @@ using NuGetUtility.Wrapper.NuGetWrapper.Packaging.Core;
 
 namespace NuGetUtility.PackageInformationReader
 {
-    public record ProjectWithReferencedPackages(string Project, IEnumerable<PackageIdentity> ReferencedPackages);
+    /// <param name="Project">The project file the packages were resolved from.</param>
+    /// <param name="ReferencedPackages">The packages referenced by the project.</param>
+    /// <param name="PackageFolders">
+    /// Local package folders (global packages folder plus any fallback folders, e.g. the SDK's
+    /// NuGetFallbackFolder) recorded in the project's assets file. Empty when no assets file is
+    /// available (e.g. packages.config projects).
+    /// </param>
+    public record ProjectWithReferencedPackages(string Project, IEnumerable<PackageIdentity> ReferencedPackages, IReadOnlyList<string> PackageFolders);
 }

--- a/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
+++ b/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using NuGetUtility.Extensions;
+using NuGetUtility.PackageInformationReader;
 using NuGetUtility.Wrapper.MsBuildWrapper;
 using NuGetUtility.Wrapper.NuGetWrapper.Frameworks;
 using NuGetUtility.Wrapper.NuGetWrapper.Packaging.Core;
@@ -30,35 +31,44 @@ namespace NuGetUtility.ReferencedPackagesReader
         /// True to exclude packages with Publish="false" metadata. When transitive dependencies are included,
         /// packages reachable only through those excluded roots are also excluded.
         /// </param>
-        /// <returns>Resolved package identities from project assets or packages.config.</returns>
-        public IEnumerable<PackageIdentity> GetInstalledPackages(string projectPath, bool includeTransitive, string? targetFramework = null, bool excludePublishFalse = false)
+        /// <returns>
+        /// The project together with its resolved package identities (from project assets or
+        /// packages.config) and the package folders recorded in the assets file (global packages folder
+        /// plus any fallback folders, e.g. the SDK's NuGetFallbackFolder; empty when no assets file is
+        /// available, such as packages.config projects).
+        /// </returns>
+        public ProjectWithReferencedPackages GetInstalledPackages(string projectPath, bool includeTransitive, string? targetFramework = null, bool excludePublishFalse = false)
         {
             IProject project = msBuild.GetProject(projectPath);
 
-            if (TryGetInstalledPackagesFromAssetsFile(includeTransitive, project, targetFramework, excludePublishFalse, out IEnumerable<PackageIdentity>? dependencies))
+            if (TryGetInstalledPackagesFromAssetsFile(includeTransitive, project, targetFramework, excludePublishFalse, out IEnumerable<PackageIdentity>? dependencies, out IReadOnlyList<string> packageFolders))
             {
-                return dependencies;
+                return new ProjectWithReferencedPackages(projectPath, dependencies, packageFolders);
             }
 
             if (project.HasPackagesConfigFile())
             {
-                return packagesConfigReader.GetPackages(project);
+                return new ProjectWithReferencedPackages(projectPath, packagesConfigReader.GetPackages(project), []);
             }
 
-            return [];
+            return new ProjectWithReferencedPackages(projectPath, [], []);
         }
 
         private bool TryGetInstalledPackagesFromAssetsFile(bool includeTransitive,
                                                            IProject project,
                                                            string? targetFramework,
                                                            bool excludePublishFalse,
-                                                           [NotNullWhen(true)] out IEnumerable<PackageIdentity>? installedPackages)
+                                                           [NotNullWhen(true)] out IEnumerable<PackageIdentity>? installedPackages,
+                                                           out IReadOnlyList<string> packageFolders)
         {
             installedPackages = null;
+            packageFolders = [];
             if (!TryLoadAssetsFile(project, out ILockFile? assetsFile))
             {
                 return false;
             }
+
+            packageFolders = assetsFile.PackageFolders.ToList();
 
             string? normalizedRequestedTargetFramework = NormalizeTargetFrameworkOrNull(targetFramework);
             List<ILockFileTarget> selectedTargets = GetSelectedTargets(assetsFile, normalizedRequestedTargetFramework, targetFramework);

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/ILockFile.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/ILockFile.cs
@@ -9,5 +9,12 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.ProjectModel
         IPackageSpec PackageSpec { get; }
         IEnumerable<ILockFileTarget> Targets { get; }
         string Path { get; }
+
+        /// <summary>
+        /// All package folders recorded in the assets file (the global packages folder followed by
+        /// any fallback folders, e.g. the SDK's NuGetFallbackFolder). Packages may be extracted into
+        /// any of these, so all must be consulted when resolving package metadata locally.
+        /// </summary>
+        IEnumerable<string> PackageFolders { get; }
     }
 }

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/WrappedLockFile.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/WrappedLockFile.cs
@@ -10,6 +10,7 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.ProjectModel
         public IPackageSpec PackageSpec => new WrappedPackageSpec(file.PackageSpec);
         public IEnumerable<ILockFileTarget> Targets => file.Targets.Select(t => new WrappedLockFileTarget(t));
         public string Path => file.Path;
+        public IEnumerable<string> PackageFolders => file.PackageFolders.Select(f => f.Path);
 
         public bool TryGetErrors(out string[] errors)
         {

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/GlobalPackagesFolderUtility.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/GlobalPackagesFolderUtility.cs
@@ -13,13 +13,45 @@ using PackageIdentity = NuGetUtility.Wrapper.NuGetWrapper.Packaging.Core.Package
 
 namespace NuGetUtility.Wrapper.NuGetWrapper.Protocol
 {
-    public class GlobalPackagesFolderUtility(ISettings settings) : IGlobalPackagesFolderUtility
+    public class GlobalPackagesFolderUtility : IGlobalPackagesFolderUtility
     {
-        private readonly string _globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
+        private readonly string[] _packageFolders;
+
+        public GlobalPackagesFolderUtility(ISettings settings, IEnumerable<string> additionalPackageFolders)
+        {
+            // The global packages folder is the primary location, but packages can also be
+            // extracted into fallback folders (e.g. the SDK's NuGetFallbackFolder) that are
+            // recorded per-project in the assets file. Consult all of them before falling back
+            // to a (slow) remote source lookup.
+            var folders = new List<string> { SettingsUtility.GetGlobalPackagesFolder(settings) };
+            foreach (string folder in additionalPackageFolders)
+            {
+                if (!string.IsNullOrEmpty(folder) && !folders.Contains(folder, StringComparer.OrdinalIgnoreCase))
+                {
+                    folders.Add(folder);
+                }
+            }
+
+            _packageFolders = [.. folders];
+        }
 
         public IWrappedPackageMetadata? GetPackage(PackageIdentity identity)
         {
-            DownloadResourceResult cachedPackage = OriginalGlobalPackagesFolderUtility.GetPackage(new OriginalPackageIdentity(identity.Id, new NuGetVersion(identity.Version.ToString()!)), _globalPackagesFolder);
+            foreach (string packageFolder in _packageFolders)
+            {
+                IWrappedPackageMetadata? metadata = TryGetPackageFromFolder(identity, packageFolder);
+                if (metadata is not null)
+                {
+                    return metadata;
+                }
+            }
+
+            return null;
+        }
+
+        private static IWrappedPackageMetadata? TryGetPackageFromFolder(PackageIdentity identity, string packageFolder)
+        {
+            DownloadResourceResult cachedPackage = OriginalGlobalPackagesFolderUtility.GetPackage(new OriginalPackageIdentity(identity.Id, new NuGetVersion(identity.Version.ToString()!)), packageFolder);
             if (cachedPackage == null)
             {
                 return null;

--- a/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
+++ b/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
@@ -64,7 +64,7 @@ namespace NuGetUtility.Test.PackageInformationReader
 
             IEnumerable<PackageIdentity> searchedPackages = customPackageInformation.Select(p => new PackageIdentity(p.Id, p.Version));
             string project = _fixture.Create<string>();
-            var packageSearchRequest = new ProjectWithReferencedPackages(project, searchedPackages);
+            var packageSearchRequest = new ProjectWithReferencedPackages(project, searchedPackages, []);
             ReferencedPackageWithContext[] result = (await localUut.GetPackageInfo(packageSearchRequest, CancellationToken.None).Synchronize())
                 .ToArray();
 
@@ -261,7 +261,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             PackageIdentity packageIdentity)
         {
             string project = _fixture.Create<string>();
-            var packageSearchRequest = new ProjectWithReferencedPackages(project, [packageIdentity]);
+            var packageSearchRequest = new ProjectWithReferencedPackages(project, [packageIdentity], []);
             ReferencedPackageWithContext[] result = (await packageInformationReader.GetPackageInfo(packageSearchRequest, CancellationToken.None).Synchronize())
                 .ToArray();
 
@@ -332,7 +332,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             IEnumerable<PackageIdentity> searchedPackages)
         {
             string project = _fixture.Create<string>();
-            var packageSearchRequest = new ProjectWithReferencedPackages(project, searchedPackages);
+            var packageSearchRequest = new ProjectWithReferencedPackages(project, searchedPackages, []);
             ReferencedPackageWithContext[] result = (await _uut!.GetPackageInfo(packageSearchRequest, CancellationToken.None).Synchronize())
                 .ToArray();
             return (project, result);

--- a/tests/NuGetUtility.Test/ReferencedPackagesReader/ReferencedPackageReaderTest.cs
+++ b/tests/NuGetUtility.Test/ReferencedPackagesReader/ReferencedPackageReaderTest.cs
@@ -58,6 +58,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
             _lockFileMock.PackageSpec.Returns(_packageSpecMock);
             _packageSpecMock.IsValid().Returns(true);
             _lockFileMock.Targets.Returns(_lockFileTargets);
+            _lockFileMock.PackageFolders.Returns([]);
             _packageSpecMock.TargetFrameworks.Returns(_packageSpecTargetFrameworks);
 
             var rnd = new Random(75643);
@@ -223,7 +224,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
         public async Task GetInstalledPackages_Should_ReturnCorrectValues_If_TargetFrameworks_Returns_Empty_And_Requested_Transitive_Packages()
         {
             _packageSpecMock.TargetFrameworks.Returns([]);
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true).ReferencedPackages;
             await Assert.That(result).IsEquivalentTo(_referencedPackagesForFramework.SelectMany(kvp => kvp.Value).Distinct());
         }
 
@@ -253,7 +254,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
         [Test]
         public async Task GetInstalledPackages_Should_ReturnCorrectValues_If_IncludingTransitive()
         {
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true).ReferencedPackages;
             await Assert.That(result).IsEquivalentTo(_referencedPackagesForFramework.SelectMany(kvp => kvp.Value).Distinct());
         }
 
@@ -279,7 +280,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             _lockFileMock.Targets.Returns([targetNet80, targetNet90]);
 
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, requestedTargetFramework);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, requestedTargetFramework).ReferencedPackages;
 
             await Assert.That(result.Select(package => package.Id)).IsEquivalentTo(["PackageNet80"]);
             await Assert.That(result.Select(package => package.Id)).DoesNotContain("PackageNet90");
@@ -307,7 +308,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             _lockFileMock.Targets.Returns([targetEquivalent, targetOther]);
 
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, requestedTargetFramework);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, requestedTargetFramework).ReferencedPackages;
 
             await Assert.That(result.Select(package => package.Id)).IsEquivalentTo(["PackageEquivalent"]);
             await Assert.That(result.Select(package => package.Id)).DoesNotContain("PackageOther");
@@ -337,7 +338,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             _lockFileMock.Targets.Returns([targetVariant, targetOther]);
 
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, requestedTargetFramework);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, requestedTargetFramework).ReferencedPackages;
 
             await Assert.That(result.Select(package => package.Id)).IsEquivalentTo(["PackageVariant"]);
             await Assert.That(result.Select(package => package.Id)).DoesNotContain("PackageOther");
@@ -346,7 +347,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
         [Test]
         public async Task GetInstalledPackages_Should_ReturnCorrectValues_If_NotIncludingTransitive()
         {
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, false);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, false).ReferencedPackages;
 
             PackageIdentity[] expectedReferences = _directlyReferencedPackagesForFramework.SelectMany(p => p.Value)
                 .Distinct()
@@ -363,7 +364,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
         {
             _projectMock.TryGetAssetsPath(out Arg.Any<string>()).Returns(false);
             _projectMock.GetEvaluatedIncludes().Returns([]);
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, false);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, false).ReferencedPackages;
 
             await Assert.That(result).Count().IsEqualTo(0);
         }
@@ -395,7 +396,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
             PackageIdentity[] expectedPackages = _referencedPackagesForFramework.First().Value;
             _packagesConfigReader.GetPackages(Arg.Any<IProject>()).Returns(expectedPackages);
 
-            IEnumerable<PackageIdentity> packages = _uut.GetInstalledPackages(_projectPath, includeTransitive);
+            IEnumerable<PackageIdentity> packages = _uut.GetInstalledPackages(_projectPath, includeTransitive).ReferencedPackages;
 
             await Assert.That(packages).IsEquivalentTo(expectedPackages);
         }
@@ -445,7 +446,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
             targetFrameworkInformation.Dependencies.Returns([excludedDependency, includedDependency]);
             _packageSpecMock.TargetFrameworks.Returns([targetFrameworkInformation]);
 
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, null, true);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, null, true).ReferencedPackages;
 
             await Assert.That(result.Select(p => p.Id)).DoesNotContain(excludedPackage);
             await Assert.That(result.Select(p => p.Id)).Contains(includedPackage);
@@ -504,7 +505,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             _projectMock.GetPackageReferencesForTarget("net9.0").Returns([]);
 
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, null, true);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, null, true).ReferencedPackages;
 
             await Assert.That(result.Select(p => p.Id).Contains(packageName)).IsTrue();
             _projectMock.Received(1).GetPackageReferencesForTarget("net8.0");
@@ -556,7 +557,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
                     })
             ]);
 
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, null, true);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, null, true).ReferencedPackages;
 
             await Assert.That(result.Select(p => p.Id)).Contains("PackageA");
             await Assert.That(result.Select(p => p.Id)).DoesNotContain("PackageB");
@@ -607,11 +608,50 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
                     })
             ]);
 
-            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, null, true);
+            IEnumerable<PackageIdentity> result = _uut.GetInstalledPackages(_projectPath, true, null, true).ReferencedPackages;
 
             await Assert.That(result.Select(p => p.Id)).Contains("PackageA");
             await Assert.That(result.Select(p => p.Id)).DoesNotContain("PackageB");
             await Assert.That(result.Select(p => p.Id)).DoesNotContain("PackageC");
+        }
+
+        [Test]
+        public async Task GetInstalledPackages_Should_ReturnPackageFolders_FromAssetsFile()
+        {
+            string[] packageFolders =
+            [
+                _fixture.Create<string>(),
+                _fixture.Create<string>()
+            ];
+            _lockFileMock.PackageFolders.Returns(packageFolders);
+
+            IReadOnlyList<string> result = _uut.GetInstalledPackages(_projectPath, true).PackageFolders;
+
+            await Assert.That(result).IsEquivalentTo(packageFolders);
+        }
+
+        [Test]
+        public async Task GetInstalledPackages_Should_ReturnEmptyPackageFolders_If_ProjectIsPackageConfigProject()
+        {
+            _projectMock.TryGetAssetsPath(out Arg.Any<string>()).Returns(false);
+            _projectMock.FullPath.Returns(_projectPath);
+            _projectMock.GetEvaluatedIncludes().Returns(new List<string> { "packages.config" });
+            _packagesConfigReader.GetPackages(Arg.Any<IProject>()).Returns(_referencedPackagesForFramework.First().Value);
+
+            IReadOnlyList<string> result = _uut.GetInstalledPackages(_projectPath, false).PackageFolders;
+
+            await Assert.That(result).Count().IsEqualTo(0);
+        }
+
+        [Test]
+        public async Task GetInstalledPackages_Should_ReturnEmptyPackageFolders_If_NoAssetsFile_And_NoPackagesConfig()
+        {
+            _projectMock.TryGetAssetsPath(out Arg.Any<string>()).Returns(false);
+            _projectMock.GetEvaluatedIncludes().Returns([]);
+
+            IReadOnlyList<string> result = _uut.GetInstalledPackages(_projectPath, false).PackageFolders;
+
+            await Assert.That(result).Count().IsEqualTo(0);
         }
 
         private static ILibraryDependency CreateDependency(string packageName)

--- a/tests/NuGetUtility.Test/ReferencedPackagesReader/ReferencedPackagesReaderIntegrationTest.cs
+++ b/tests/NuGetUtility.Test/ReferencedPackagesReader/ReferencedPackagesReaderIntegrationTest.cs
@@ -51,7 +51,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             string path = Path.GetFullPath("../../../../targets/PackageReferenceProject/PackageReferenceProject.csproj");
 
-            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, false);
+            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, false).ReferencedPackages;
 
             await Assert.That(result.Count()).IsEqualTo(1);
         }
@@ -67,7 +67,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
             string path = Path.GetFullPath(
                 "../../../../targets/ProjectWithTransitiveReferences/ProjectWithTransitiveReferences.csproj");
 
-            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, true);
+            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, true).ReferencedPackages;
 
             await Assert.That(result.Count()).IsEqualTo(2);
         }
@@ -83,7 +83,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
             string path = Path.GetFullPath(
                 "../../../../targets/ProjectWithTransitiveNuget/ProjectWithTransitiveNuget.csproj");
 
-            PackageIdentity[] result = _uut!.GetInstalledPackages(path, true).ToArray();
+            PackageIdentity[] result = _uut!.GetInstalledPackages(path, true).ReferencedPackages.ToArray();
 
             await Assert.That(result.Length).IsEqualTo(3);
             string[] titles = result.Select(metadata => metadata.Id).ToArray();
@@ -103,7 +103,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
             string path = Path.GetFullPath(
                 "../../../../targets/ProjectWithoutNugetReferences/ProjectWithoutNugetReferences.csproj");
 
-            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, false);
+            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, false).ReferencedPackages;
 
             await Assert.That(result.Count()).IsEqualTo(0);
         }
@@ -121,7 +121,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
             string path = Path.GetFullPath(
                 "../../../../targets/VersionRangesProject/VersionRangesProject.csproj");
 
-            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, includeTransitive);
+            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, includeTransitive).ReferencedPackages;
 
             await Assert.That(result.Count()).IsEqualTo(includeTransitive ? 3 : 1);
         }
@@ -136,7 +136,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             string path = Path.GetFullPath("../../../../targets/PackagesConfigProject/PackagesConfigProject.csproj");
 
-            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, false);
+            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, false).ReferencedPackages;
 
             await Assert.That(result.Count()).IsEqualTo(1);
         }
@@ -169,7 +169,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             string path = Path.GetFullPath("../../../../targets/SimpleCppProject/SimpleCppProject.vcxproj");
 
-            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, includeTransitive);
+            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, includeTransitive).ReferencedPackages;
 
             await Assert.That(result.Count()).IsEqualTo(2);
         }
@@ -205,7 +205,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             string path = Path.GetFullPath("../../../../targets/EmptyCppProject/EmptyCppProject.vcxproj");
 
-            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, includeTransitive);
+            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, includeTransitive).ReferencedPackages;
 
             await Assert.That(result.Count()).IsEqualTo(0);
         }
@@ -244,7 +244,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             string path = Path.GetFullPath("../../../../targets/MultiTargetProjectWithDifferentDependencies/MultiTargetProjectWithDifferentDependencies.csproj");
 
-            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, includeTransitive, framework);
+            IEnumerable<PackageIdentity> result = _uut!.GetInstalledPackages(path, includeTransitive, framework).ReferencedPackages;
 
             await Assert.That(result.Select(p => p.Id)).IsEquivalentTo(packages);
         }


### PR DESCRIPTION
## Problem
Package metadata is resolved from the global packages folder, falling back to a remote source lookup when a package isn't found there. Packages provided only via a **fallback folder** (e.g. the SDK's `NuGetFallbackFolder`) are never written to the global packages folder by `dotnet restore`, so each such package incurs a remote service-index + auth round-trip. On a 36-project solution this meant ~80 round-trips and a ~260s `-t` run (highly variable with feed latency).

## Fix
Read the `packageFolders` already recorded in each project's `project.assets.json` (the global packages folder plus any fallback folders) and consult all of them when resolving package metadata, before falling back to a remote source.

## Result
On the same 36-project solution: **~260s → ~10s**, with byte-identical output. No new dependencies.

Added unit tests covering that `ReferencedPackageReader` surfaces the assets package folders. Full suite passes on net8.0/net9.0/net10.0/net472 and `dotnet format --verify-no-changes` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package lookups now consider multiple local package folders, not just the main global cache.
  * Project package data now includes package-folder information alongside referenced packages.

* **Bug Fixes**
  * Improved package resolution for projects that use fallback folders or alternate local package locations.
  * Package metadata retrieval now uses the correct per-project folder context for more accurate results.

* **Tests**
  * Updated coverage to reflect the new package-folder-aware behavior and revised package lookup results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->