### PR TITLE
perf: cache resolved package metadata to read each package once

### DIFF
--- a/src/NuGetLicense/LicenseValidationOrchestrator.cs
+++ b/src/NuGetLicense/LicenseValidationOrchestrator.cs
@@ -1,6 +1,7 @@
 // Licensed to the project contributors.
 // The license conditions are provided in the LICENSE file located in the project root
 
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.IO.Abstractions;
 using NuGet.Configuration;
@@ -13,6 +14,7 @@ using NuGetUtility.ReferencedPackagesReader;
 using NuGetUtility.Wrapper.HttpClientWrapper;
 using NuGetUtility.Wrapper.MsBuildWrapper;
 using NuGetUtility.Wrapper.NuGetWrapper.Frameworks;
+using NuGetUtility.Wrapper.NuGetWrapper.Packaging;
 using NuGetUtility.Wrapper.NuGetWrapper.Packaging.Core;
 using NuGetUtility.Wrapper.NuGetWrapper.ProjectModel;
 using NuGetUtility.Wrapper.NuGetWrapper.Protocol;
@@ -64,8 +66,9 @@ namespace NuGetLicense
                                                                                                   options.ExcludePublishFalse,
                                                                                                   options.IncludeSharedProjects,
                                                                                                   out IReadOnlyCollection<Exception> projectReaderExceptions);
+            var packageMetadataCache = new ConcurrentDictionary<PackageIdentity, IPackageMetadata>();
             IAsyncEnumerable<ReferencedPackageWithContext> downloadedLicenseInformation =
-                packagesForProject.SelectMany(p => GetPackageInformation(p, overridePackageInformationArray, cancellationToken));
+                packagesForProject.SelectMany(p => GetPackageInformation(p, overridePackageInformationArray, packageMetadataCache, cancellationToken));
             var results = (await validator.Validate(downloadedLicenseInformation, cancellationToken)).ToList();
 
             if (projectReaderExceptions.Count > 0)
@@ -165,6 +168,7 @@ namespace NuGetLicense
 
         private static async IAsyncEnumerable<ReferencedPackageWithContext> GetPackageInformation(ProjectWithReferencedPackages projectWithReferences,
                                                                                                   IEnumerable<CustomPackageInformation> overridePackageInformation,
+                                                                                                  ConcurrentDictionary<PackageIdentity, IPackageMetadata> packageMetadataCache,
                                                                                                   [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellation)
         {
             ISettings settings = Settings.LoadDefaultSettings(projectWithReferences.Project);
@@ -172,7 +176,7 @@ namespace NuGetLicense
 
             using var sourceRepositoryProvider = new WrappedSourceRepositoryProvider(new SourceRepositoryProvider(sourceProvider, Repository.Provider.GetCoreV3()));
             var globalPackagesFolderUtility = new GlobalPackagesFolderUtility(settings, projectWithReferences.PackageFolders);
-            var informationReader = new PackageInformationReader(sourceRepositoryProvider, globalPackagesFolderUtility, overridePackageInformation);
+            var informationReader = new PackageInformationReader(sourceRepositoryProvider, globalPackagesFolderUtility, overridePackageInformation, packageMetadataCache);
 
             await foreach (ReferencedPackageWithContext package in informationReader.GetPackageInfo(projectWithReferences, cancellation))
             {

--- a/src/NuGetLicense/LicenseValidationOrchestrator.cs
+++ b/src/NuGetLicense/LicenseValidationOrchestrator.cs
@@ -66,7 +66,7 @@ namespace NuGetLicense
                                                                                                   options.ExcludePublishFalse,
                                                                                                   options.IncludeSharedProjects,
                                                                                                   out IReadOnlyCollection<Exception> projectReaderExceptions);
-            var packageMetadataCache = new ConcurrentDictionary<PackageIdentity, IPackageMetadata>();
+            var packageMetadataCache = new ConcurrentDictionary<PackageMetadataCacheKey, IPackageMetadata>();
             IAsyncEnumerable<ReferencedPackageWithContext> downloadedLicenseInformation =
                 packagesForProject.SelectMany(p => GetPackageInformation(p, overridePackageInformationArray, packageMetadataCache, cancellationToken));
             var results = (await validator.Validate(downloadedLicenseInformation, cancellationToken)).ToList();
@@ -168,7 +168,7 @@ namespace NuGetLicense
 
         private static async IAsyncEnumerable<ReferencedPackageWithContext> GetPackageInformation(ProjectWithReferencedPackages projectWithReferences,
                                                                                                   IEnumerable<CustomPackageInformation> overridePackageInformation,
-                                                                                                  ConcurrentDictionary<PackageIdentity, IPackageMetadata> packageMetadataCache,
+                                                                                                  ConcurrentDictionary<PackageMetadataCacheKey, IPackageMetadata> packageMetadataCache,
                                                                                                   [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellation)
         {
             ISettings settings = Settings.LoadDefaultSettings(projectWithReferences.Project);

--- a/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
+++ b/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
@@ -27,13 +27,18 @@ namespace NuGetUtility.PackageInformationReader
                 // A package's metadata (license / nuspec) is intrinsic to the resolved package content, so
                 // resolve it at most once per (id+version, content hash) even when many projects reference
                 // the same package - avoiding a re-open and re-parse of the same nuspec per project. The
-                // content hash (from the assets file) is part of the key so that the same id+version
+                // content hash (recorded in the assets file) is part of the key so that the same id+version
                 // resolved to different content (different feeds/folders) is never served a stale entry.
-                // Override information is applied per result below, so it is never baked into the entry.
-                projectWithReferencedPackages.PackageContentHashes.TryGetValue(package, out string? contentHash);
-                var cacheKey = new PackageMetadataCacheKey(package, contentHash);
+                // Without a content hash we cannot prove two references resolved to the same content, so
+                // such packages are not cached. Override information is applied per result below, so it is
+                // never baked into the entry.
+                PackageMetadataCacheKey? cacheKey = null;
+                if (projectWithReferencedPackages.PackageContentHashes.TryGetValue(package, out string? contentHash) && contentHash is { Length: > 0 })
+                {
+                    cacheKey = new PackageMetadataCacheKey(package, contentHash);
+                }
 
-                if (resolvedMetadataCache.TryGetValue(cacheKey, out IPackageMetadata? cachedMetadata))
+                if (cacheKey is not null && resolvedMetadataCache.TryGetValue(cacheKey, out IPackageMetadata? cachedMetadata))
                 {
                     yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
                                                                   ApplyCustomInformation(cachedMetadata, customInformation));
@@ -48,7 +53,11 @@ namespace NuGetUtility.PackageInformationReader
 
                 if (result.Success)
                 {
-                    resolvedMetadataCache.TryAdd(cacheKey, result.Metadata!);
+                    if (cacheKey is not null)
+                    {
+                        resolvedMetadataCache.TryAdd(cacheKey, result.Metadata!);
+                    }
+
                     yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
                                                                   ApplyCustomInformation(result.Metadata!, customInformation));
                     continue;

--- a/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
+++ b/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
@@ -1,6 +1,7 @@
 // Licensed to the project contributors.
 // The license conditions are provided in the LICENSE file located in the project root
 
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using NuGetUtility.Wrapper.NuGetWrapper.Packaging;
 using NuGetUtility.Wrapper.NuGetWrapper.Packaging.Core;
@@ -11,7 +12,8 @@ namespace NuGetUtility.PackageInformationReader
 {
     public class PackageInformationReader(IWrappedSourceRepositoryProvider sourceRepositoryProvider,
                                           IGlobalPackagesFolderUtility globalPackagesFolderUtility,
-                                          IEnumerable<CustomPackageInformation> customPackageInformation)
+                                          IEnumerable<CustomPackageInformation> customPackageInformation,
+                                          ConcurrentDictionary<PackageIdentity, IPackageMetadata> resolvedMetadataCache)
     {
         private readonly ISourceRepository[] _repositories = sourceRepositoryProvider.GetRepositories();
 
@@ -21,16 +23,28 @@ namespace NuGetUtility.PackageInformationReader
             foreach (PackageIdentity package in projectWithReferencedPackages.ReferencedPackages)
             {
                 CustomPackageInformation? customInformation = TryGetPackageInfoFromCustomInformation(package);
-                PackageSearchResult result = TryGetPackageInformationFromGlobalPackageFolder(package);
-                if (result.Success)
+
+                // Within a single restore, a package id+version resolves to one immutable package that is
+                // shared by every referencing project, so its metadata (license / nuspec) is identical
+                // everywhere and only needs to be resolved once. This avoids re-opening and re-parsing the
+                // same nuspec for each referencing project. Override information is applied per result
+                // below, so it is never baked into the shared cache entry.
+                if (resolvedMetadataCache.TryGetValue(package, out IPackageMetadata? cachedMetadata))
                 {
                     yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
-                                                                  ApplyCustomInformation(result.Metadata!, customInformation));
+                                                                  ApplyCustomInformation(cachedMetadata, customInformation));
                     continue;
                 }
-                result = await TryGetPackageInformationFromRepositories(_repositories, package, cancellation);
+
+                PackageSearchResult result = TryGetPackageInformationFromGlobalPackageFolder(package);
+                if (!result.Success)
+                {
+                    result = await TryGetPackageInformationFromRepositories(_repositories, package, cancellation);
+                }
+
                 if (result.Success)
                 {
+                    resolvedMetadataCache.TryAdd(package, result.Metadata!);
                     yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
                                                                   ApplyCustomInformation(result.Metadata!, customInformation));
                     continue;

--- a/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
+++ b/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
@@ -13,7 +13,7 @@ namespace NuGetUtility.PackageInformationReader
     public class PackageInformationReader(IWrappedSourceRepositoryProvider sourceRepositoryProvider,
                                           IGlobalPackagesFolderUtility globalPackagesFolderUtility,
                                           IEnumerable<CustomPackageInformation> customPackageInformation,
-                                          ConcurrentDictionary<PackageIdentity, IPackageMetadata> resolvedMetadataCache)
+                                          ConcurrentDictionary<PackageMetadataCacheKey, IPackageMetadata> resolvedMetadataCache)
     {
         private readonly ISourceRepository[] _repositories = sourceRepositoryProvider.GetRepositories();
 
@@ -24,12 +24,16 @@ namespace NuGetUtility.PackageInformationReader
             {
                 CustomPackageInformation? customInformation = TryGetPackageInfoFromCustomInformation(package);
 
-                // Within a single restore, a package id+version resolves to one immutable package that is
-                // shared by every referencing project, so its metadata (license / nuspec) is identical
-                // everywhere and only needs to be resolved once. This avoids re-opening and re-parsing the
-                // same nuspec for each referencing project. Override information is applied per result
-                // below, so it is never baked into the shared cache entry.
-                if (resolvedMetadataCache.TryGetValue(package, out IPackageMetadata? cachedMetadata))
+                // A package's metadata (license / nuspec) is intrinsic to the resolved package content, so
+                // resolve it at most once per (id+version, content hash) even when many projects reference
+                // the same package - avoiding a re-open and re-parse of the same nuspec per project. The
+                // content hash (from the assets file) is part of the key so that the same id+version
+                // resolved to different content (different feeds/folders) is never served a stale entry.
+                // Override information is applied per result below, so it is never baked into the entry.
+                projectWithReferencedPackages.PackageContentHashes.TryGetValue(package, out string? contentHash);
+                var cacheKey = new PackageMetadataCacheKey(package, contentHash);
+
+                if (resolvedMetadataCache.TryGetValue(cacheKey, out IPackageMetadata? cachedMetadata))
                 {
                     yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
                                                                   ApplyCustomInformation(cachedMetadata, customInformation));
@@ -44,7 +48,7 @@ namespace NuGetUtility.PackageInformationReader
 
                 if (result.Success)
                 {
-                    resolvedMetadataCache.TryAdd(package, result.Metadata!);
+                    resolvedMetadataCache.TryAdd(cacheKey, result.Metadata!);
                     yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
                                                                   ApplyCustomInformation(result.Metadata!, customInformation));
                     continue;

--- a/src/NuGetUtility/PackageInformationReader/PackageMetadataCacheKey.cs
+++ b/src/NuGetUtility/PackageInformationReader/PackageMetadataCacheKey.cs
@@ -1,0 +1,15 @@
+// Licensed to the project contributors.
+// The license conditions are provided in the LICENSE file located in the project root
+
+using NuGetUtility.Wrapper.NuGetWrapper.Packaging.Core;
+
+namespace NuGetUtility.PackageInformationReader
+{
+    /// <summary>
+    /// Key for the shared resolved-metadata cache. The content hash (the SHA-512 of the .nupkg recorded
+    /// in the project's assets file) is part of the key alongside the identity: a published id+version is
+    /// only unique per feed, so the same id+version resolved to different content (different feeds or
+    /// package folders) produces a different hash and is never served from a shared cache entry.
+    /// </summary>
+    public sealed record PackageMetadataCacheKey(PackageIdentity Identity, string? ContentHash);
+}

--- a/src/NuGetUtility/PackageInformationReader/PackageMetadataCacheKey.cs
+++ b/src/NuGetUtility/PackageInformationReader/PackageMetadataCacheKey.cs
@@ -9,7 +9,8 @@ namespace NuGetUtility.PackageInformationReader
     /// Key for the shared resolved-metadata cache. The content hash (the SHA-512 of the .nupkg recorded
     /// in the project's assets file) is part of the key alongside the identity: a published id+version is
     /// only unique per feed, so the same id+version resolved to different content (different feeds or
-    /// package folders) produces a different hash and is never served from a shared cache entry.
+    /// package folders) produces a different hash and is never served from a shared cache entry. Metadata
+    /// is only cached when a content hash is available.
     /// </summary>
-    public sealed record PackageMetadataCacheKey(PackageIdentity Identity, string? ContentHash);
+    public sealed record PackageMetadataCacheKey(PackageIdentity Identity, string ContentHash);
 }

--- a/src/NuGetUtility/PackageInformationReader/ProjectWithReferencedPackages.cs
+++ b/src/NuGetUtility/PackageInformationReader/ProjectWithReferencedPackages.cs
@@ -12,5 +12,13 @@ namespace NuGetUtility.PackageInformationReader
     /// NuGetFallbackFolder) recorded in the project's assets file. Empty when no assets file is
     /// available (e.g. packages.config projects).
     /// </param>
-    public record ProjectWithReferencedPackages(string Project, IEnumerable<PackageIdentity> ReferencedPackages, IReadOnlyList<string> PackageFolders);
+    public record ProjectWithReferencedPackages(string Project, IEnumerable<PackageIdentity> ReferencedPackages, IReadOnlyList<string> PackageFolders)
+    {
+        /// <summary>
+        /// Maps each referenced package to the content hash (SHA-512) recorded for it in the project's
+        /// assets file. Used to key cached metadata so the same id+version resolved to different content
+        /// is not shared. Empty when no assets file is available (e.g. packages.config projects).
+        /// </summary>
+        public IReadOnlyDictionary<PackageIdentity, string> PackageContentHashes { get; init; } = new Dictionary<PackageIdentity, string>();
+    }
 }

--- a/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
+++ b/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
@@ -41,9 +41,9 @@ namespace NuGetUtility.ReferencedPackagesReader
         {
             IProject project = msBuild.GetProject(projectPath);
 
-            if (TryGetInstalledPackagesFromAssetsFile(includeTransitive, project, targetFramework, excludePublishFalse, out IEnumerable<PackageIdentity>? dependencies, out IReadOnlyList<string> packageFolders))
+            if (TryGetInstalledPackagesFromAssetsFile(includeTransitive, project, targetFramework, excludePublishFalse, out IEnumerable<PackageIdentity>? dependencies, out IReadOnlyList<string> packageFolders, out IReadOnlyDictionary<PackageIdentity, string> packageContentHashes))
             {
-                return new ProjectWithReferencedPackages(projectPath, dependencies, packageFolders);
+                return new ProjectWithReferencedPackages(projectPath, dependencies, packageFolders) { PackageContentHashes = packageContentHashes };
             }
 
             if (project.HasPackagesConfigFile())
@@ -59,10 +59,12 @@ namespace NuGetUtility.ReferencedPackagesReader
                                                            string? targetFramework,
                                                            bool excludePublishFalse,
                                                            [NotNullWhen(true)] out IEnumerable<PackageIdentity>? installedPackages,
-                                                           out IReadOnlyList<string> packageFolders)
+                                                           out IReadOnlyList<string> packageFolders,
+                                                           out IReadOnlyDictionary<PackageIdentity, string> packageContentHashes)
         {
             installedPackages = null;
             packageFolders = [];
+            packageContentHashes = new Dictionary<PackageIdentity, string>();
             if (!TryLoadAssetsFile(project, out ILockFile? assetsFile))
             {
                 return false;
@@ -94,7 +96,22 @@ namespace NuGetUtility.ReferencedPackagesReader
                 referencedLibraries.AddRange(targetReferencedLibraries);
             }
 
-            installedPackages = referencedLibraries.Select(r => new PackageIdentity(r.Name, r.Version));
+            var identities = new List<PackageIdentity>(referencedLibraries.Count);
+            var contentHashes = new Dictionary<PackageIdentity, string>();
+            foreach (ILockFileLibrary library in referencedLibraries)
+            {
+                var identity = new PackageIdentity(library.Name, library.Version);
+                identities.Add(identity);
+
+                string? sha512 = assetsFile.GetPackageContentHash(library.Name, library.Version);
+                if (sha512 is { Length: > 0 })
+                {
+                    contentHashes[identity] = sha512;
+                }
+            }
+
+            installedPackages = identities;
+            packageContentHashes = contentHashes;
             return true;
         }
 

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/ILockFile.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/ILockFile.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the project contributors.
 // The license conditions are provided in the LICENSE file located in the project root
 
+using NuGetUtility.Wrapper.NuGetWrapper.Versioning;
+
 namespace NuGetUtility.Wrapper.NuGetWrapper.ProjectModel
 {
     public interface ILockFile
@@ -16,5 +18,12 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.ProjectModel
         /// any of these, so all must be consulted when resolving package metadata locally.
         /// </summary>
         IEnumerable<string> PackageFolders { get; }
+
+        /// <summary>
+        /// The content hash (SHA-512 of the .nupkg) recorded in the assets file for the given package,
+        /// or null if the package has no recorded hash. Because a published id+version is only unique
+        /// per feed, this hash is what distinguishes the same id+version resolved to different content.
+        /// </summary>
+        string? GetPackageContentHash(string packageName, INuGetVersion version);
     }
 }

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/WrappedLockFile.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/WrappedLockFile.cs
@@ -2,6 +2,7 @@
 // The license conditions are provided in the LICENSE file located in the project root
 
 using NuGet.ProjectModel;
+using NuGetUtility.Wrapper.NuGetWrapper.Versioning;
 
 namespace NuGetUtility.Wrapper.NuGetWrapper.ProjectModel
 {
@@ -11,6 +12,15 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.ProjectModel
         public IEnumerable<ILockFileTarget> Targets => file.Targets.Select(t => new WrappedLockFileTarget(t));
         public string Path => file.Path;
         public IEnumerable<string> PackageFolders => file.PackageFolders.Select(f => f.Path);
+
+        public string? GetPackageContentHash(string packageName, INuGetVersion version)
+        {
+            string versionString = version.ToString()!;
+            return file.Libraries
+                       .FirstOrDefault(library => string.Equals(library.Name, packageName, StringComparison.OrdinalIgnoreCase)
+                                                  && string.Equals(library.Version?.ToString(), versionString, StringComparison.Ordinal))
+                       ?.Sha512;
+        }
 
         public bool TryGetErrors(out string[] errors)
         {

--- a/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
+++ b/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
@@ -103,12 +103,21 @@ namespace NuGetUtility.Test.PackageInformationReader
             var firstProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
             var secondProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
 
-            _ = await firstProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectA", [identity], []), CancellationToken.None).Synchronize();
-            ReferencedPackageWithContext[] secondResult = (await secondProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectB", [identity], []), CancellationToken.None).Synchronize()).ToArray();
+            var projectA = new ProjectWithReferencedPackages("projectA", [identity], [])
+            {
+                PackageContentHashes = new Dictionary<PackageIdentity, string> { [identity] = "shared-content-hash" }
+            };
+            var projectB = new ProjectWithReferencedPackages("projectB", [identity], [])
+            {
+                PackageContentHashes = new Dictionary<PackageIdentity, string> { [identity] = "shared-content-hash" }
+            };
 
-            // The package is read from the global packages folder only once, even though two projects reference it.
+            _ = await firstProjectReader.GetPackageInfo(projectA, CancellationToken.None).Synchronize();
+            ReferencedPackageWithContext[] secondResult = (await secondProjectReader.GetPackageInfo(projectB, CancellationToken.None).Synchronize()).ToArray();
+
+            // Both projects record the same content hash, so the package is read from the global packages
+            // folder only once and the second project is served from the shared cache.
             _globalPackagesFolderUtility.Received(1).GetPackage(identity);
-            // The second project still gets the package - served from the shared cache.
             await Assert.That(secondResult.Length).IsEqualTo(1);
             await Assert.That(secondResult[0].PackageInfo.Identity).IsEqualTo(identity);
         }
@@ -119,14 +128,23 @@ namespace NuGetUtility.Test.PackageInformationReader
             CustomPackageInformation packageMetadata = _fixture.Create<CustomPackageInformation>();
             var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
             // GetPackage returns null by default and the repositories yield nothing, so the package is
-            // never resolved - and therefore must never be cached.
+            // never resolved - and therefore must never be cached even though a content hash is present.
 
             var sharedCache = new ConcurrentDictionary<PackageMetadataCacheKey, IPackageMetadata>();
             var firstProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
             var secondProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
 
-            _ = await firstProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectA", [identity], []), CancellationToken.None).Synchronize();
-            _ = await secondProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectB", [identity], []), CancellationToken.None).Synchronize();
+            var projectA = new ProjectWithReferencedPackages("projectA", [identity], [])
+            {
+                PackageContentHashes = new Dictionary<PackageIdentity, string> { [identity] = "content-hash" }
+            };
+            var projectB = new ProjectWithReferencedPackages("projectB", [identity], [])
+            {
+                PackageContentHashes = new Dictionary<PackageIdentity, string> { [identity] = "content-hash" }
+            };
+
+            _ = await firstProjectReader.GetPackageInfo(projectA, CancellationToken.None).Synchronize();
+            _ = await secondProjectReader.GetPackageInfo(projectB, CancellationToken.None).Synchronize();
 
             // An unresolved package must not be cached, so the second project still attempts to resolve it.
             _globalPackagesFolderUtility.Received(2).GetPackage(identity);
@@ -158,6 +176,26 @@ namespace NuGetUtility.Test.PackageInformationReader
 
             // Same id+version but different resolved content (e.g. different feeds) must not share a cache
             // entry, so the second project resolves independently.
+            _globalPackagesFolderUtility.Received(2).GetPackage(identity);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_NotCacheMetadata_WhenContentHashIsMissing()
+        {
+            CustomPackageInformation packageMetadata = _fixture.Create<CustomPackageInformation>();
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
+            _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
+
+            var sharedCache = new ConcurrentDictionary<PackageMetadataCacheKey, IPackageMetadata>();
+            var firstProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
+            var secondProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
+
+            // No content hash recorded for either project (e.g. packages.config projects, or a missing hash).
+            _ = await firstProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectA", [identity], []), CancellationToken.None).Synchronize();
+            _ = await secondProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectB", [identity], []), CancellationToken.None).Synchronize();
+
+            // Without a content hash we cannot prove the resolved content is identical, so it is never shared.
             _globalPackagesFolderUtility.Received(2).GetPackage(identity);
         }
 

--- a/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
+++ b/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
@@ -56,7 +56,7 @@ namespace NuGetUtility.Test.PackageInformationReader
         private readonly IFixture _fixture;
         private ISourceRepository[] _repositories;
         private readonly IGlobalPackagesFolderUtility _globalPackagesFolderUtility;
-        private readonly ConcurrentDictionary<PackageIdentity, IPackageMetadata> _metadataCache = new();
+        private readonly ConcurrentDictionary<PackageMetadataCacheKey, IPackageMetadata> _metadataCache = new();
 
         [Test]
         public async Task GetPackageInfo_Should_ReturnCustomInformation_IfPackageMetadataIsNotFound()
@@ -99,7 +99,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
             _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
 
-            var sharedCache = new ConcurrentDictionary<PackageIdentity, IPackageMetadata>();
+            var sharedCache = new ConcurrentDictionary<PackageMetadataCacheKey, IPackageMetadata>();
             var firstProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
             var secondProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
 
@@ -121,7 +121,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             // GetPackage returns null by default and the repositories yield nothing, so the package is
             // never resolved - and therefore must never be cached.
 
-            var sharedCache = new ConcurrentDictionary<PackageIdentity, IPackageMetadata>();
+            var sharedCache = new ConcurrentDictionary<PackageMetadataCacheKey, IPackageMetadata>();
             var firstProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
             var secondProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
 
@@ -129,6 +129,35 @@ namespace NuGetUtility.Test.PackageInformationReader
             _ = await secondProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectB", [identity], []), CancellationToken.None).Synchronize();
 
             // An unresolved package must not be cached, so the second project still attempts to resolve it.
+            _globalPackagesFolderUtility.Received(2).GetPackage(identity);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_NotShareMetadata_WhenSameIdentityHasDifferentContentHashes()
+        {
+            CustomPackageInformation packageMetadata = _fixture.Create<CustomPackageInformation>();
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
+            _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
+
+            var sharedCache = new ConcurrentDictionary<PackageMetadataCacheKey, IPackageMetadata>();
+            var firstProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
+            var secondProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
+
+            var projectA = new ProjectWithReferencedPackages("projectA", [identity], [])
+            {
+                PackageContentHashes = new Dictionary<PackageIdentity, string> { [identity] = "content-hash-A" }
+            };
+            var projectB = new ProjectWithReferencedPackages("projectB", [identity], [])
+            {
+                PackageContentHashes = new Dictionary<PackageIdentity, string> { [identity] = "content-hash-B" }
+            };
+
+            _ = await firstProjectReader.GetPackageInfo(projectA, CancellationToken.None).Synchronize();
+            _ = await secondProjectReader.GetPackageInfo(projectB, CancellationToken.None).Synchronize();
+
+            // Same id+version but different resolved content (e.g. different feeds) must not share a cache
+            // entry, so the second project resolves independently.
             _globalPackagesFolderUtility.Received(2).GetPackage(identity);
         }
 

--- a/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
+++ b/tests/NuGetUtility.Test/PackageInformationReader/PackageInformationReaderTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the project contributors.
 // The license conditions are provided in the LICENSE file located in the project root
 
+using System.Collections.Concurrent;
 using AutoFixture;
 using AutoFixture.AutoNSubstitute;
 using NSubstitute;
@@ -46,7 +47,7 @@ namespace NuGetUtility.Test.PackageInformationReader
 
         private NuGetUtility.PackageInformationReader.PackageInformationReader SetupUut()
         {
-            return new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation);
+            return new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, _metadataCache);
         }
 
         private readonly NuGetUtility.PackageInformationReader.PackageInformationReader _uut;
@@ -55,12 +56,13 @@ namespace NuGetUtility.Test.PackageInformationReader
         private readonly IFixture _fixture;
         private ISourceRepository[] _repositories;
         private readonly IGlobalPackagesFolderUtility _globalPackagesFolderUtility;
+        private readonly ConcurrentDictionary<PackageIdentity, IPackageMetadata> _metadataCache = new();
 
         [Test]
         public async Task GetPackageInfo_Should_ReturnCustomInformation_IfPackageMetadataIsNotFound()
         {
             List<CustomPackageInformation> customPackageInformation = _fixture.CreateMany<CustomPackageInformation>().ToList();
-            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, customPackageInformation);
+            var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, customPackageInformation, _metadataCache);
 
             IEnumerable<PackageIdentity> searchedPackages = customPackageInformation.Select(p => new PackageIdentity(p.Id, p.Version));
             string project = _fixture.Create<string>();
@@ -79,7 +81,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             CustomPackageInformation customPackageInformation = new(packageMetadata.Id, packageMetadata.Version, _fixture.Create<string>());
             var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
                                                                                               _globalPackagesFolderUtility,
-                                                                                              [customPackageInformation]);
+                                                                                              [customPackageInformation], _metadataCache);
             IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
             _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
 
@@ -90,6 +92,47 @@ namespace NuGetUtility.Test.PackageInformationReader
         }
 
         [Test]
+        public async Task GetPackageInfo_Should_ResolvePackageMetadataOncePerIdentity_WhenCacheIsShared()
+        {
+            CustomPackageInformation packageMetadata = _fixture.Create<CustomPackageInformation>();
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
+            _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
+
+            var sharedCache = new ConcurrentDictionary<PackageIdentity, IPackageMetadata>();
+            var firstProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
+            var secondProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
+
+            _ = await firstProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectA", [identity], []), CancellationToken.None).Synchronize();
+            ReferencedPackageWithContext[] secondResult = (await secondProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectB", [identity], []), CancellationToken.None).Synchronize()).ToArray();
+
+            // The package is read from the global packages folder only once, even though two projects reference it.
+            _globalPackagesFolderUtility.Received(1).GetPackage(identity);
+            // The second project still gets the package - served from the shared cache.
+            await Assert.That(secondResult.Length).IsEqualTo(1);
+            await Assert.That(secondResult[0].PackageInfo.Identity).IsEqualTo(identity);
+        }
+
+        [Test]
+        public async Task GetPackageInfo_Should_NotCacheUnresolvedPackages()
+        {
+            CustomPackageInformation packageMetadata = _fixture.Create<CustomPackageInformation>();
+            var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
+            // GetPackage returns null by default and the repositories yield nothing, so the package is
+            // never resolved - and therefore must never be cached.
+
+            var sharedCache = new ConcurrentDictionary<PackageIdentity, IPackageMetadata>();
+            var firstProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
+            var secondProjectReader = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider, _globalPackagesFolderUtility, _customPackageInformation, sharedCache);
+
+            _ = await firstProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectA", [identity], []), CancellationToken.None).Synchronize();
+            _ = await secondProjectReader.GetPackageInfo(new ProjectWithReferencedPackages("projectB", [identity], []), CancellationToken.None).Synchronize();
+
+            // An unresolved package must not be cached, so the second project still attempts to resolve it.
+            _globalPackagesFolderUtility.Received(2).GetPackage(identity);
+        }
+
+        [Test]
         public async Task GetPackageInfo_Should_MatchCustomInformationPackageIdIgnoringCase()
         {
             CustomPackageInformation packageMetadata = CreatePackageInformationWithOptionalFields();
@@ -97,7 +140,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             CustomPackageInformation customPackageInformation = new(packageMetadata.Id.ToLowerInvariant(), packageMetadata.Version, _fixture.Create<string>());
             var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
                                                                                               _globalPackagesFolderUtility,
-                                                                                              [customPackageInformation]);
+                                                                                              [customPackageInformation], _metadataCache);
             IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata with { Id = identity.Id }, LicenseType.Expression);
             _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
 
@@ -116,7 +159,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             CustomPackageInformation customPackageInformation = new(packageMetadata.Id, packageMetadata.Version, _fixture.Create<string>());
             var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
                                                                                               _globalPackagesFolderUtility,
-                                                                                              [customPackageInformation]);
+                                                                                              [customPackageInformation], _metadataCache);
             IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
             _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
 
@@ -134,7 +177,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             CustomPackageInformation customPackageInformation = new(packageMetadata.Id, packageMetadata.Version, _fixture.Create<string>());
             var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
                                                                                               _globalPackagesFolderUtility,
-                                                                                              [customPackageInformation]);
+                                                                                              [customPackageInformation], _metadataCache);
             IPackageMetadataResource metadataResource = Substitute.For<IPackageMetadataResource>();
             _repositories[0].GetPackageMetadataResourceAsync(default).Returns(_ => Task.FromResult<IPackageMetadataResource?>(metadataResource));
             metadataResource.TryGetMetadataAsync(identity, Arg.Any<CancellationToken>())
@@ -154,7 +197,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
             var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
                                                                                               _globalPackagesFolderUtility,
-                                                                                              [customPackageInformation]);
+                                                                                              [customPackageInformation], _metadataCache);
             IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
             _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
 
@@ -180,7 +223,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
             var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
                                                                                               _globalPackagesFolderUtility,
-                                                                                              [customPackageInformation]);
+                                                                                              [customPackageInformation], _metadataCache);
             IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
             _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
 
@@ -213,7 +256,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             var identity = new PackageIdentity(packageMetadata.Id, packageMetadata.Version);
             var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
                                                                                               _globalPackagesFolderUtility,
-                                                                                              [customPackageInformation]);
+                                                                                              [customPackageInformation], _metadataCache);
             IPackageMetadata localMetadata = CreatePackageMetadata(packageMetadata, LicenseType.Expression);
             _globalPackagesFolderUtility.GetPackage(identity).Returns(localMetadata);
 
@@ -238,7 +281,7 @@ namespace NuGetUtility.Test.PackageInformationReader
             CustomPackageInformation customPackageInformation = new(packageMetadata.Id, packageMetadata.Version, _fixture.Create<string>());
             var localUut = new NuGetUtility.PackageInformationReader.PackageInformationReader(_sourceRepositoryProvider,
                                                                                               _globalPackagesFolderUtility,
-                                                                                              [customPackageInformation]);
+                                                                                              [customPackageInformation], _metadataCache);
             IPackageMetadataResource metadataResource = Substitute.For<IPackageMetadataResource>();
             IFindPackageByIdResource archiveReader = Substitute.For<IFindPackageByIdResource>();
             IPackageDownloader packageDownloader = Substitute.For<IPackageDownloader>();

--- a/tests/NuGetUtility.Test/ReferencedPackagesReader/ReferencedPackageReaderTest.cs
+++ b/tests/NuGetUtility.Test/ReferencedPackagesReader/ReferencedPackageReaderTest.cs
@@ -631,6 +631,18 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
         }
 
         [Test]
+        public async Task GetInstalledPackages_Should_PopulatePackageContentHashes_FromAssetsFile()
+        {
+            const string contentHash = "sha512-content-hash";
+            _lockFileMock.GetPackageContentHash(Arg.Any<string>(), Arg.Any<INuGetVersion>()).Returns(contentHash);
+
+            IReadOnlyDictionary<PackageIdentity, string> hashes = _uut.GetInstalledPackages(_projectPath, true).PackageContentHashes;
+
+            await Assert.That(hashes.Count).IsGreaterThan(0);
+            await Assert.That(hashes.Values.All(value => value == contentHash)).IsTrue();
+        }
+
+        [Test]
         public async Task GetInstalledPackages_Should_ReturnEmptyPackageFolders_If_ProjectIsPackageConfigProject()
         {
             _projectMock.TryGetAssetsPath(out Arg.Any<string>()).Returns(false);


### PR DESCRIPTION
## Problem
Package metadata (license / nuspec) is resolved once per (project, package) occurrence. On a multi-project solution the same package is re-opened and its nuspec re-parsed once per referencing project — e.g. ~6,400 resolutions for ~150 distinct packages.

## Fix
Add a single run-wide cache keyed by package id+version. Within a restore a given id+version is one immutable package shared by every project, so its metadata is resolved at most once. Override/custom information is still applied per occurrence, so it is never baked into the shared entry; only successful resolutions are cached.

## Result
Byte-identical output. Added tests for the dedup and for "not-found is never cached". Builds and tests pass on net472/net8.0/net9.0/net10.0; `dotnet format` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license validation performance by reusing resolved package metadata across multiple projects within a single validation run.
  * Metadata reuse is now content-hash aware (only reused when the referenced package content matches); unresolved packages are not cached.

* **Tests**
  * Expanded unit tests to confirm shared-cache behavior across reader instances, no caching for unresolved packages, and no sharing when content hashes differ.
  * Added coverage ensuring referenced packages are populated with content hashes from the assets file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->