### PR TITLE
Fix SonarCloud issues in new code

### DIFF
--- a/src/FileLicenseMatcher/SPDX/JavaCore/SpdxLicenseTemplateHelper.cs
+++ b/src/FileLicenseMatcher/SPDX/JavaCore/SpdxLicenseTemplateHelper.cs
@@ -42,7 +42,7 @@ public static class SpdxLicenseTemplateHelper
         while (ruleMatcher.MoveNext())
         {
             // copy everything up to the start of the find
-            string upToTheFind = licenseTemplate.Substring(end, ruleMatcher.Current!.Index - end);
+            string upToTheFind = licenseTemplate.Substring(end, ruleMatcher.Current.Index - end);
             if (!string.IsNullOrWhiteSpace(upToTheFind))
             {
                 templateOutputHandler.text(upToTheFind);

--- a/src/FileLicenseMatcher/SPDX/JavaLibrary/ParseInstruction.cs
+++ b/src/FileLicenseMatcher/SPDX/JavaLibrary/ParseInstruction.cs
@@ -631,9 +631,12 @@ public sealed class ParseInstruction
                 return [];
             }
             var tokens = new List<string>();
-            foreach (IReadOnlyList<string> t in nextInstruction.SubInstructions.Select(i => i.TokenizedText).Where(t => t is not null)!)
+            foreach (ParseInstruction subInstruction in nextInstruction.SubInstructions)
             {
-                tokens.AddRange(t);
+                if (subInstruction.TokenizedText is { } tokenizedText)
+                {
+                    tokens.AddRange(tokenizedText);
+                }
             }
             return tokens;
         }

--- a/src/NuGetLicense/CommandLineOptionsParser.cs
+++ b/src/NuGetLicense/CommandLineOptionsParser.cs
@@ -70,7 +70,8 @@ namespace NuGetLicense
             }
 
             string jsonContent = fileSystem.File.ReadAllText(licenseMapping);
-            Dictionary<Uri, string> userDictionary = JsonSerializer.Deserialize(jsonContent, CommandLineOptionsJsonContext.Default.DictionaryUriString)!;
+            Dictionary<Uri, string> userDictionary = JsonSerializer.Deserialize(jsonContent, CommandLineOptionsJsonContext.Default.DictionaryUriString)
+                ?? throw new ArgumentException($"File '{licenseMapping}' contains invalid JSON: expected a license mapping but got null.");
 
             return UrlToLicenseMapping.Default.SetItems(userDictionary);
         }
@@ -102,9 +103,11 @@ namespace NuGetLicense
                 return spdxLicenseMatcher;
             }
 
-            string containingDirectory = fileSystem.Path.GetDirectoryName(fileSystem.Path.GetFullPath(licenseFileMappings))!;
+            string containingDirectory = fileSystem.Path.GetDirectoryName(fileSystem.Path.GetFullPath(licenseFileMappings))
+                ?? throw new ArgumentException($"Could not determine the containing directory of license file mapping '{licenseFileMappings}'.");
             string jsonContent = fileSystem.File.ReadAllText(licenseFileMappings);
-            Dictionary<string, string> rawMappings = JsonSerializer.Deserialize(jsonContent, CommandLineOptionsJsonContext.Default.DictionaryStringString)!;
+            Dictionary<string, string> rawMappings = JsonSerializer.Deserialize(jsonContent, CommandLineOptionsJsonContext.Default.DictionaryStringString)
+                ?? throw new ArgumentException($"File '{licenseFileMappings}' contains invalid JSON: expected a file mapping but got null.");
             var fullPathMappings = rawMappings.ToDictionary(kvp => fileSystem.Path.GetFullPath(fileSystem.Path.Combine(containingDirectory, kvp.Key)), kvp => kvp.Value);
 
             return new FileLicenseMatcher.Combine.LicenseMatcher([

--- a/src/NuGetLicense/Output/Csv/CsvOutputFormatter.cs
+++ b/src/NuGetLicense/Output/Csv/CsvOutputFormatter.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using NuGetLicense.LicenseValidator;
+using NuGetUtility.Extensions;
 
 namespace NuGetLicense.Output.Csv
 {
@@ -49,18 +50,18 @@ namespace NuGetLicense.Output.Csv
 
         private static string EscapeCsvValue(string? value)
         {
-            if (string.IsNullOrEmpty(value))
+            if (value.IsNullOrEmpty())
             {
                 return string.Empty;
             }
 
             if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
             {
-                string escaped = value!.Replace("\"", "\"\"");
+                string escaped = value.Replace("\"", "\"\"");
                 return $"\"{escaped}\"";
             }
 
-            return value!;
+            return value;
         }
 
         private static string GetValidationErrorsString(IEnumerable<ValidationError> errors)

--- a/src/NuGetUtility/AppLifetime.cs
+++ b/src/NuGetUtility/AppLifetime.cs
@@ -51,7 +51,9 @@ namespace NuGetUtility
                 }
             }
 
-            _doneEvent.Wait(TimeSpan.FromSeconds(5));
+            // Wait unconditionally for graceful completion: cancellation has just been requested on _cts,
+            // so passing that token would abort the wait immediately instead of giving Main time to exit.
+            _doneEvent.Wait(TimeSpan.FromSeconds(5), CancellationToken.None);
         }
 
         public void Done(int result)

--- a/src/NuGetUtility/Extensions/StringExtensions.cs
+++ b/src/NuGetUtility/Extensions/StringExtensions.cs
@@ -1,12 +1,20 @@
 ﻿// Licensed to the project contributors.
 // The license conditions are provided in the LICENSE file located in the project root
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
 namespace NuGetUtility.Extensions
 {
     public static class StringExtensions
     {
+        // Wraps string.IsNullOrEmpty with the null-state annotation the framework method lacks on net472,
+        // so callers get null-narrowing after the check instead of needing a null-forgiving operator.
+        public static bool IsNullOrEmpty([NotNullWhen(false)] this string? value)
+        {
+            return string.IsNullOrEmpty(value);
+        }
+
         /// <summary>
         /// Compares the string against a given pattern.
         /// </summary>

--- a/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
+++ b/src/NuGetUtility/PackageInformationReader/PackageInformationReader.cs
@@ -23,68 +23,73 @@ namespace NuGetUtility.PackageInformationReader
             foreach (PackageIdentity package in projectWithReferencedPackages.ReferencedPackages)
             {
                 CustomPackageInformation? customInformation = TryGetPackageInfoFromCustomInformation(package);
+                PackageMetadataCacheKey? cacheKey = TryCreateCacheKey(projectWithReferencedPackages, package);
 
-                // A package's metadata (license / nuspec) is intrinsic to the resolved package content, so
-                // resolve it at most once per (id+version, content hash) even when many projects reference
-                // the same package - avoiding a re-open and re-parse of the same nuspec per project. The
-                // content hash (recorded in the assets file) is part of the key so that the same id+version
-                // resolved to different content (different feeds/folders) is never served a stale entry.
-                // Without a content hash we cannot prove two references resolved to the same content, so
-                // such packages are not cached. Override information is applied per result below, so it is
-                // never baked into the entry.
-                PackageMetadataCacheKey? cacheKey = null;
-                if (projectWithReferencedPackages.PackageContentHashes.TryGetValue(package, out string? contentHash) && contentHash is { Length: > 0 })
+                IPackageMetadata? metadata = TryGetCachedMetadata(cacheKey);
+                if (metadata is null)
                 {
-                    cacheKey = new PackageMetadataCacheKey(package, contentHash);
-                }
+                    metadata = TryGetPackageInformationFromGlobalPackageFolder(package)
+                               ?? await TryGetPackageInformationFromRepositories(_repositories, package, cancellation);
 
-                if (cacheKey is not null && resolvedMetadataCache.TryGetValue(cacheKey, out IPackageMetadata? cachedMetadata))
-                {
-                    yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
-                                                                  ApplyCustomInformation(cachedMetadata, customInformation));
-                    continue;
-                }
-
-                PackageSearchResult result = TryGetPackageInformationFromGlobalPackageFolder(package);
-                if (!result.Success)
-                {
-                    result = await TryGetPackageInformationFromRepositories(_repositories, package, cancellation);
-                }
-
-                if (result.Success)
-                {
-                    if (cacheKey is not null)
+                    if (metadata is not null && cacheKey is not null)
                     {
-                        resolvedMetadataCache.TryAdd(cacheKey, result.Metadata!);
+                        resolvedMetadataCache.TryAdd(cacheKey, metadata);
                     }
+                }
 
-                    yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
-                                                                  ApplyCustomInformation(result.Metadata!, customInformation));
-                    continue;
-                }
-                if (customInformation is not null)
-                {
-                    yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
-                                                                  new PackageMetadata(package, customInformation));
-                    continue;
-                }
-                // simply return input - validation will fail later, as the required fields are missing
-                yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project, new PackageMetadata(package));
+                yield return new ReferencedPackageWithContext(projectWithReferencedPackages.Project,
+                                                              BuildPackageMetadata(package, metadata, customInformation));
             }
         }
-        private PackageSearchResult TryGetPackageInformationFromGlobalPackageFolder(PackageIdentity package)
+
+        // A package's metadata (license / nuspec) is intrinsic to the resolved package content, so
+        // resolve it at most once per (id+version, content hash) even when many projects reference
+        // the same package - avoiding a re-open and re-parse of the same nuspec per project. The
+        // content hash (recorded in the assets file) is part of the key so that the same id+version
+        // resolved to different content (different feeds/folders) is never served a stale entry.
+        // Without a content hash we cannot prove two references resolved to the same content, so
+        // such packages are not cached. Override information is applied per result, so it is
+        // never baked into the entry.
+        private static PackageMetadataCacheKey? TryCreateCacheKey(ProjectWithReferencedPackages projectWithReferencedPackages, PackageIdentity package)
         {
-            IPackageMetadata? metadata = globalPackagesFolderUtility.GetPackage(package);
+            if (projectWithReferencedPackages.PackageContentHashes.TryGetValue(package, out string? contentHash) && contentHash is { Length: > 0 })
+            {
+                return new PackageMetadataCacheKey(package, contentHash);
+            }
+            return null;
+        }
+
+        private IPackageMetadata? TryGetCachedMetadata(PackageMetadataCacheKey? cacheKey)
+        {
+            if (cacheKey is not null && resolvedMetadataCache.TryGetValue(cacheKey, out IPackageMetadata? cachedMetadata))
+            {
+                return cachedMetadata;
+            }
+            return null;
+        }
+
+        private static IPackageMetadata BuildPackageMetadata(PackageIdentity package, IPackageMetadata? metadata, CustomPackageInformation? customInformation)
+        {
             if (metadata is not null)
             {
-                return new PackageSearchResult(metadata);
+                return ApplyCustomInformation(metadata, customInformation);
             }
-            return new PackageSearchResult();
+            if (customInformation is not null)
+            {
+                return new PackageMetadata(package, customInformation);
+            }
+            // simply return input - validation will fail later, as the required fields are missing
+            return new PackageMetadata(package);
         }
 
-        private static async Task<PackageSearchResult> TryGetPackageInformationFromRepositories(ISourceRepository[] repositories,
-                                                                                                PackageIdentity package,
-                                                                                                CancellationToken cancellation)
+        private IPackageMetadata? TryGetPackageInformationFromGlobalPackageFolder(PackageIdentity package)
+        {
+            return globalPackagesFolderUtility.GetPackage(package);
+        }
+
+        private static async Task<IPackageMetadata?> TryGetPackageInformationFromRepositories(ISourceRepository[] repositories,
+                                                                                              PackageIdentity package,
+                                                                                              CancellationToken cancellation)
         {
             foreach (ISourceRepository repository in repositories)
             {
@@ -95,24 +100,26 @@ namespace NuGetUtility.PackageInformationReader
                 }
 
                 IPackageMetadata? updatedPackageMetadata = await resource.TryGetMetadataAsync(package, cancellation);
-                if (updatedPackageMetadata is not null)
+                if (updatedPackageMetadata is null)
                 {
-                    if (updatedPackageMetadata.LicenseMetadata is LicenseMetadata.File file)
-                    {
-                        IPackageDownloader? downloader = await TryGetPackageDownloaderAsync(repository, package, cancellation);
-                        if (downloader is not null)
-                        {
-                            return new PackageSearchResult(new LicenseAugmentedPackageMetadata(updatedPackageMetadata,
-                                                                                               await downloader.ReadAsync(file.FileLocation, cancellation)));
-                        }
-                        return new PackageSearchResult();
-                    }
-
-                    return new PackageSearchResult(updatedPackageMetadata);
+                    continue;
                 }
+
+                if (updatedPackageMetadata.LicenseMetadata is not LicenseMetadata.File file)
+                {
+                    return updatedPackageMetadata;
+                }
+
+                IPackageDownloader? downloader = await TryGetPackageDownloaderAsync(repository, package, cancellation);
+                if (downloader is null)
+                {
+                    return null;
+                }
+                return new LicenseAugmentedPackageMetadata(updatedPackageMetadata,
+                                                           await downloader.ReadAsync(file.FileLocation, cancellation));
             }
 
-            return new PackageSearchResult();
+            return null;
         }
 
         private CustomPackageInformation? TryGetPackageInfoFromCustomInformation(PackageIdentity package)
@@ -158,23 +165,6 @@ namespace NuGetUtility.PackageInformationReader
             catch (Exception)
             {
                 return null;
-            }
-        }
-
-        private sealed record PackageSearchResult
-        {
-            public bool Success { get; }
-            public IPackageMetadata? Metadata { get; }
-
-            public PackageSearchResult(IPackageMetadata metadata)
-            {
-                Success = true;
-                Metadata = metadata;
-            }
-
-            public PackageSearchResult()
-            {
-                Success = false;
             }
         }
     }

--- a/src/NuGetUtility/Serialization/NuGetVersionJsonConverter.cs
+++ b/src/NuGetUtility/Serialization/NuGetVersionJsonConverter.cs
@@ -16,8 +16,7 @@ namespace NuGetUtility.Serialization
                 throw new JsonException("NuGet version needs to be serialized as a string.");
             }
 
-            // we already know that the token is a string so we can safely call GetString() without checking for null
-            string stringVersion = reader.GetString()!;
+            string? stringVersion = reader.GetString();
             if (WrappedNuGetVersion.TryParse(stringVersion, out WrappedNuGetVersion? version))
             {
                 return version;

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/AssetsPackageDependencyReader.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/AssetsPackageDependencyReader.cs
@@ -77,35 +77,40 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.ProjectModel
 
                 foreach (ILockFileTargetLibrary library in target.Libraries)
                 {
-                    if (!string.Equals(library.Type, PackageTypeIdentifier, StringComparison.OrdinalIgnoreCase))
-                    {
-                        continue;
-                    }
-
-                    string packageNameValue = library.Name.Trim();
-                    if (string.IsNullOrEmpty(packageNameValue))
-                    {
-                        continue;
-                    }
-
-                    if (!packageDependencies.TryGetValue(packageNameValue, out HashSet<string>? dependencies))
-                    {
-                        dependencies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                        packageDependencies[packageNameValue] = dependencies;
-                    }
-
-                    foreach (string dependencyName in library.Dependencies.Select(d => d.Id))
-                    {
-                        dependencies.Add(dependencyName);
-                        if (!packageDependencies.ContainsKey(dependencyName))
-                        {
-                            packageDependencies[dependencyName] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                        }
-                    }
+                    CollectLibraryDependencies(packageDependencies, library);
                 }
             }
 
             return packageDependencies;
+        }
+
+        private static void CollectLibraryDependencies(Dictionary<string, HashSet<string>> packageDependencies, ILockFileTargetLibrary library)
+        {
+            if (!string.Equals(library.Type, PackageTypeIdentifier, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            string packageNameValue = library.Name.Trim();
+            if (string.IsNullOrEmpty(packageNameValue))
+            {
+                return;
+            }
+
+            if (!packageDependencies.TryGetValue(packageNameValue, out HashSet<string>? dependencies))
+            {
+                dependencies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                packageDependencies[packageNameValue] = dependencies;
+            }
+
+            foreach (string dependencyName in library.Dependencies.Select(d => d.Id))
+            {
+                dependencies.Add(dependencyName);
+                if (!packageDependencies.ContainsKey(dependencyName))
+                {
+                    packageDependencies[dependencyName] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                }
+            }
         }
     }
 }

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/WrappedLockFile.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/WrappedLockFile.cs
@@ -15,7 +15,7 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.ProjectModel
 
         public string? GetPackageContentHash(string packageName, INuGetVersion version)
         {
-            string versionString = version.ToString()!;
+            string versionString = version.ToString();
             return file.Libraries
                        .FirstOrDefault(library => string.Equals(library.Name, packageName, StringComparison.OrdinalIgnoreCase)
                                                   && string.Equals(library.Version?.ToString(), versionString, StringComparison.Ordinal))

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/Core/Types/CachingFindPackageByIdResource.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/Core/Types/CachingFindPackageByIdResource.cs
@@ -15,7 +15,7 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.Protocol.Core.Types
             try
             {
                 NuGet.Packaging.IPackageDownloader result = await findPackageByIdResource.GetPackageDownloaderAsync(
-                    new NuGet.Packaging.Core.PackageIdentity(identity.Id, new NuGetVersion(identity.Version.ToString()!)),
+                    new NuGet.Packaging.Core.PackageIdentity(identity.Id, new NuGetVersion(identity.Version.ToString())),
                     cacheContext,
                     NullLogger.Instance,
                     cancellationToken);

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/Core/Types/CachingPackageMetadataResource.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/Core/Types/CachingPackageMetadataResource.cs
@@ -18,7 +18,7 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.Protocol.Core.Types
         {
             try
             {
-                IPackageSearchMetadata result = await metadataResource.GetMetadataAsync(new NuGet.Packaging.Core.PackageIdentity(identity.Id, new NuGetVersion(identity.Version.ToString()!)),
+                IPackageSearchMetadata result = await metadataResource.GetMetadataAsync(new NuGet.Packaging.Core.PackageIdentity(identity.Id, new NuGetVersion(identity.Version.ToString())),
                                                                                         cacheContext,
                                                                                         NullLogger.Instance,
                                                                                         cancellationToken);

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/GlobalPackagesFolderUtility.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/GlobalPackagesFolderUtility.cs
@@ -41,7 +41,7 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.Protocol
 
         private static IWrappedPackageMetadata? TryGetPackageFromFolder(PackageIdentity identity, string packageFolder)
         {
-            DownloadResourceResult cachedPackage = OriginalGlobalPackagesFolderUtility.GetPackage(new OriginalPackageIdentity(identity.Id, new NuGetVersion(identity.Version.ToString()!)), packageFolder);
+            DownloadResourceResult cachedPackage = OriginalGlobalPackagesFolderUtility.GetPackage(new OriginalPackageIdentity(identity.Id, new NuGetVersion(identity.Version.ToString())), packageFolder);
             if (cachedPackage == null)
             {
                 return null;

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/Versioning/INuGetVersion.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/Versioning/INuGetVersion.cs
@@ -3,5 +3,10 @@
 
 namespace NuGetUtility.Wrapper.NuGetWrapper.Versioning
 {
-    public interface INuGetVersion : IComparable<INuGetVersion> { }
+    public interface INuGetVersion : IComparable<INuGetVersion>
+    {
+        // Declared non-nullable so callers reconstructing a NuGetVersion from the string do not have to
+        // guard against the nullable object.ToString() the interface would otherwise expose.
+        string ToString();
+    }
 }

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/Versioning/WrappedNuGetVersion.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/Versioning/WrappedNuGetVersion.cs
@@ -61,7 +61,7 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.Versioning
             return _version;
         }
 
-        internal static bool TryParse(string stringVersion, [NotNullWhen(true)] out WrappedNuGetVersion? version)
+        internal static bool TryParse(string? stringVersion, [NotNullWhen(true)] out WrappedNuGetVersion? version)
         {
             if (NuGetVersion.TryParse(stringVersion, out NuGetVersion? internalVersion))
             {


### PR DESCRIPTION
## Summary

Fixes the [SonarCloud complaints](https://sonarcloud.io/summary/new_code?id=sensslen_nuget-license) reported on the new-code period.

## Changes

**S3776 (cognitive complexity)**
- `PackageInformationReader.GetPackageInfo`: extracted cache-key resolution, cache lookup, and result building into helpers. This also removed the `PackageSearchResult` wrapper (and its null-forgiving operators) in favor of returning `IPackageMetadata?` directly.
- `AssetsPackageDependencyReader`: split the per-library processing into `CollectLibraryDependencies`.

**S8949 (bug)**
- `AppLifetime.Shutdown` now passes `CancellationToken.None` to `ManualResetEventSlim.Wait`. Passing the just-cancelled `_cts.Token` would abort the wait immediately and defeat the graceful-shutdown wait.

**S8970 (null-forgiving operator)**
- Added an annotated `string.IsNullOrEmpty` wrapper so callers narrow instead of using `!`.
- Declared a non-nullable `ToString()` on `INuGetVersion` so version reconstruction needs no fallback.
- `WrappedNuGetVersion.TryParse` now accepts a nullable string, letting `NuGetVersionJsonConverter` drop the operator without an artificial throw.
- Genuinely-nullable results (`JsonSerializer.Deserialize`, `Path.GetDirectoryName`) are handled with explicit exceptions.
- Legitimate suppressions (caller-guaranteed invariants the compiler cannot prove, e.g. `CompareTemplateOutputHandler`, `LicenseValidator`) are left in place.

## Testing

- `dotnet build NuGetUtility.sln`: 0 warnings, 0 errors (net472/net8.0/net9.0/net10.0, `TreatWarningsAsErrors` on).
- `NuGetUtility.Test`: 168 passed.
- `FileLicenseMatcher.Test`: 674 passed.
- `NuGetLicense.Test`: the non-snapshot tests pass; the Verify snapshot tests fail identically with and without this change due to a pre-existing CRLF checkout issue on the local machine, so they are unaffected by these edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation when loading license mapping files, with clearer errors for invalid or incomplete configuration.
  - Improved package metadata and license resolution across local and configured package sources.
  - Ensured application shutdown waits for graceful completion after cancellation.
  - Preserved correct CSV escaping for commas, quotes, and line breaks.

- **Refactor**
  - Simplified package and dependency metadata processing while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->