### PR TITLE
CI: run the url-to-license-mapping tests only once

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -115,9 +115,10 @@ jobs:
         shell: pwsh
         run: |
           $failed = $false
-          Get-ChildItem "tests\*\bin\TestWindows\${{ matrix.framework }}\NuGet*.Test.exe" | ForEach-Object {
-            Write-Host "Running: $_"
-            & "$_"
+          "NuGetUtility.Test", "NuGetLicense.Test" | ForEach-Object {
+            $exe = "tests\$_\bin\TestWindows\${{ matrix.framework }}\$_.exe"
+            Write-Host "Running: $exe"
+            & $exe
             if ($LASTEXITCODE -ne 0) { $failed = $true }
           }
           if ($failed) { exit 1 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,15 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
 
-      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
-
       - name: build
         run: msbuild -t:rebuild -restore -p:RestorePackagesConfig=true -property:Configuration=Release NuGetUtility.slnx
 
       - name: test
         uses: josepho0918/vstest-action@678efa7c0bdf7a46f6977b47c50f9c6a184ae00e
         with:
-          testAssembly: "NuGet*.Test.dll"
+          testAssembly: |
+            NuGetUtility.Test.dll
+            NuGetLicense.Test.dll
           searchFolder: "tests/*/bin/Release/net10.0/"
           runInParallel: true
 


### PR DESCRIPTION
`test_windows` and the release job both discovered test executables with a `NuGet*.Test` glob. `NuGetUtility.UrlToLicenseMapping.Test` matches it, so the Selenium suite ran a second time on top of its own `test_url_to_license_mapping` job (visible in #636).

Both jobs now name the two projects they are meant to cover. The release job's `browser-actions/setup-chrome` step is removed with it, since Chrome was only needed by the url-mapping tests.

Two consequences:
- A new `NuGet*.Test` project no longer joins those jobs on its own. It has to be added to the list.
- A missing executable now fails `test_windows` instead of being silently skipped, which the glob hid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)