### PR TITLE
Add .NET 11 support

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -15,17 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
 
-        framework: [net8.0, net9.0, net10.0]
-
-        include:
-          - framework: net8.0
-            dotnetVersion: "8.0.x"
-
-          - framework: net9.0
-            dotnetVersion: "9.0.x"
-
-          - framework: net10.0
-            dotnetVersion: "10.0.x"
+        framework: [net8.0, net9.0, net10.0, net11.0]
 
     steps:
       - uses: actions/checkout@v7
@@ -37,6 +27,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+            11.0.100-rc.1.26425.128
 
       - name: restore
         run: dotnet restore NuGetUtility.slnx
@@ -63,6 +54,7 @@ jobs:
         with:
           dotnet-version: | 
             10.0.x
+            11.0.100-rc.1.26425.128
          
       - name: restore
         run: dotnet restore NuGetUtility.slnx
@@ -80,6 +72,7 @@ jobs:
         with:
           dotnet-version: | 
             10.0.x
+            11.0.100-rc.1.26425.128
       
       - uses: browser-actions/setup-chrome@48ad923757ca74d66703209fe939badbdf80f2f4 # v2.2.0
       
@@ -93,7 +86,7 @@ jobs:
     runs-on: windows-2025-vs2026
     strategy:
       matrix:
-        framework: [net8.0, net472, net9.0, net10.0]
+        framework: [net8.0, net472, net9.0, net10.0, net11.0]
     steps:
       - uses: actions/checkout@v7
 
@@ -104,6 +97,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+            11.0.100-rc.1.26425.128
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
@@ -135,6 +129,7 @@ jobs:
           dotnet-version: | 
             9.0.x
             10.0.x
+            11.0.100-rc.1.26425.128
 
       - name: restore
         run: dotnet restore NuGetUtility.slnx
@@ -146,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        framework: [net8.0, net9.0, net10.0]
+        framework: [net8.0, net9.0, net10.0, net11.0]
         project: [App, Tests, ProjectWithReferenceContainingLicenseExpression, ProjectWithReferenceContainingFileLicense, ProjectWithReferenceContainingWindowsSpecificPath]
 
     steps:
@@ -161,6 +156,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+            11.0.100-rc.1.26425.128
 
       - name: restore
         run: dotnet restore NuGetUtility.slnx -p:TargetFramework=${{ matrix.framework }}
@@ -253,6 +249,7 @@ jobs:
           dotnet-version: | 
             9.0.x
             10.0.x
+            11.0.100-rc.1.26425.128
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
@@ -345,7 +342,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        framework: [net8.0, net9.0, net10.0]
+        framework: [net8.0, net9.0, net10.0, net11.0]
 
     steps:
       - uses: actions/checkout@v7
@@ -359,6 +356,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+            11.0.100-rc.1.26425.128
 
       - name: restore
         run: dotnet restore NuGetUtility.slnx -p:TargetFramework=${{ matrix.framework }}
@@ -394,6 +392,7 @@ jobs:
           dotnet-version: | 
             9.0.x
             10.0.x
+            11.0.100-rc.1.26425.128
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+            11.0.100-rc.1.26425.128
 
       - uses: nowsprinting/check-version-format-action@cb3beb7706ccf9e542ff67c752b61b21cfff5068 # v5.0.5
         id: version
@@ -56,6 +57,8 @@ jobs:
         run: dotnet publish ./src/NuGetLicenseCore/NuGetLicenseCore.csproj -c Release --no-restore -o ${{ steps.artifacts_path.outputs.path }}/net9 -f net9.0 -p:Version=${{ steps.version.outputs.full_without_prefix }} -p:ContinuousIntegrationBuild=true
       - name: Publish the application binaries (.net10)
         run: dotnet publish ./src/NuGetLicenseCore/NuGetLicenseCore.csproj -c Release --no-restore -o ${{ steps.artifacts_path.outputs.path }}/net10 -f net10.0 -p:Version=${{ steps.version.outputs.full_without_prefix }} -p:ContinuousIntegrationBuild=true
+      - name: Publish the application binaries (.net11)
+        run: dotnet publish ./src/NuGetLicenseCore/NuGetLicenseCore.csproj -c Release --no-restore -o ${{ steps.artifacts_path.outputs.path }}/net11 -f net11.0 -p:Version=${{ steps.version.outputs.full_without_prefix }} -p:ContinuousIntegrationBuild=true
       - name: Publish the application binaries (.net472)
         run: msbuild ./src/NuGetLicenseFramework/NuGetLicenseFramework.csproj /t:Publish /p:configuration=Release /p:PublishDir=${{ steps.artifacts_path.outputs.path }}/net472 /p:Version=${{ steps.version.outputs.full_without_prefix }} /p:ContinuousIntegrationBuild=true
       - name: Create nuget package

--- a/global.json
+++ b/global.json
@@ -2,6 +2,9 @@
   "test": {
     "runner": "Microsoft.Testing.Platform"
   },
+  // The Windows jobs build through Visual Studio MSBuild, whose SDK resolver skips prerelease
+  // SDKs unless global.json names one. Without this it picks the newest stable SDK on the
+  // runner and every net11.0 target fails with NETSDK1045. Drop it once .NET 11 is stable.
   "sdk": {
     "version": "11.0.100-rc.1.26425.128",
     "rollForward": "latestMinor"

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "sdk": {
-    "version": "10.0.102",
+    "version": "11.0.100-rc.1.26425.128",
     "rollForward": "latestMinor"
   }
 }

--- a/src/FileLicenseMatcher/FileLicenseMatcher.csproj
+++ b/src/FileLicenseMatcher/FileLicenseMatcher.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <Configurations>Debug;Release;TestWindows</Configurations>

--- a/src/NuGetLicense/NuGetLicense.csproj
+++ b/src/NuGetLicense/NuGetLicense.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <RepositoryType>git</RepositoryType>
     <Version>100.100.100</Version>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>

--- a/src/NuGetLicenseCore/NuGetLicenseCore.csproj
+++ b/src/NuGetLicenseCore/NuGetLicenseCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <PackageType>DotnetTool</PackageType>

--- a/src/NuGetUtility/NuGetUtility.csproj
+++ b/src/NuGetUtility/NuGetUtility.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <RepositoryType>git</RepositoryType>
     <Version>100.100.100</Version>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
@@ -38,6 +38,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" Version="18.9.6" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" Version="18.10.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/tests/NuGetLicense.Test/NuGetLicense.Test.csproj
+++ b/tests/NuGetLicense.Test/NuGetLicense.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/NuGetUtility.Test.Extensions/NuGetUtility.Test.Extensions.csproj
+++ b/tests/NuGetUtility.Test.Extensions/NuGetUtility.Test.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/NuGetUtility.Test/NuGetUtility.Test.csproj
+++ b/tests/NuGetUtility.Test/NuGetUtility.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Adds `net11.0` across the source, test and tool projects, and publishes a net11 asset on the next release.

`Microsoft.Build` is pinned to `18.10.1` for net11.0. That is the release that swapped its net10.0 lib for net11.0 and broke the build last week, so the net11 build has been sitting there waiting.

`global.json` moves to `11.0.100-rc.1.26425.128`. Building a net11.0 target needs the 11 SDK, and it still builds net8.0 through net10.0. The workflows pin that exact RC rather than `11.0.x`, which setup-dotnet will not resolve to a prerelease. Both need a bump on each RC drop until GA.

No dependency upgrades were needed. Every direct package already ships a net8.0-or-lower core asset, which is forward compatible with net11.0, and Verify.TUnit already has a net11.0 lib. No new snapshot files either, since Verify names them by parameter hash rather than by target framework.

Also drops the `test` matrix `include` block. Its `dotnetVersion` values were never referenced.

## Worth knowing before merge

.NET 11 is RC1, go-live but not GA until around November. Merging this ships a tool asset built against a runtime users cannot yet install from a stable channel.

Two things I could not check locally and am watching CI for:

- `check_code_format` runs on ubuntu. On Windows, the RC's `dotnet format` crashes on the legacy packages.config fixture (`tests/targets/PackagesConfigProject`) inside Roslyn's .NET Framework build host, deterministically, and it reproduces on `main` with only the SDK bumped, so it is an upstream regression rather than anything here. Linux has no Framework build host, so it may not surface at all. If it does, the only workaround I found that works is running format per project, since `--exclude` filters files but still loads the project.
- `test_windows` and the release job build through VS msbuild. Whether that picks up the setup-dotnet installed 11 SDK is unproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added .NET 11 support across the application and related libraries.
  - Added .NET 11 builds to release artifacts.
  - Added compatibility with the .NET 11 release candidate SDK.

- **Tests**
  - Extended automated testing and validation to run against .NET 11.
  - Added .NET 11 coverage for license and utility test projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->