### PR TITLE
Remove comments that restate the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@
 
 This repository provides two main tools:
 
-| Tool | Description | Supported Project Types |
-|------|-------------|------------------------|
-| **NuGetLicenseCore**<br/>(dotnet tool) | Cross-platform .NET Core global tool, installed via `dotnet tool install`. | .NET Core, .NET Standard, partial .NET Framework<sup>1</sup> |
-| **NuGetLicenseFramework.exe** | Standalone .NET Framework executable. | .NET Core, .NET Standard, .NET Framework, native C++ |
-
-<sup>1</sup> .NET Framework support via the dotnet tool may vary due to MSBuild/environment differences.
+| Tool | Description |
+|------|-------------|
+| **NuGetLicenseCore**<br/>(dotnet tool) | Cross-platform .NET Core global tool, installed via `dotnet tool install`. |
+| **NuGetLicenseFramework.exe** | Standalone .NET Framework executable. |
 
 ## Compatibility Matrix
 
 | Tool | .NET Core | .NET Standard | .NET Framework | Native C++ |
 |------|:---------:|:-------------:|:--------------:|:----------:|
-| **NuGetLicenseCore**<br/>(dotnet tool) | ✔️ | ✔️ | ⚠️<br/>Partial support | ❌ |
+| **NuGetLicenseCore**<br/>(dotnet tool) | ✔️ | ✔️ | ⚠️<br/>Partial support<sup>1</sup> | ❌ |
 | **NuGetLicenseFramework.exe** | ✔️ | ✔️ | ✔️ | ✔️ |
+
+<sup>1</sup> .NET Framework support via the dotnet tool may vary due to MSBuild/environment differences.
 
 ## Installation
 

--- a/src/FileLicenseMatcher/SPDX/FastLicenseMatcher.cs
+++ b/src/FileLicenseMatcher/SPDX/FastLicenseMatcher.cs
@@ -80,7 +80,6 @@ namespace FileLicenseMatcher.SPDX
             int end = 0;
             while (ruleMatches.MoveNext())
             {
-                // copy everything up to the start of the find
                 string upToTheFind = licenseTemplate.Substring(end, ruleMatches.Current.Index - end);
                 if (!string.IsNullOrWhiteSpace(upToTheFind))
                 {
@@ -123,7 +122,6 @@ namespace FileLicenseMatcher.SPDX
             {
                 throw new LicenseTemplateRuleException("Missing EndOptional rule and end of text");
             }
-            // copy the rest of the template to the end
             ParseInstruction result = instructionStack.Pop();
             string restOfTemplate = licenseTemplate.Substring(end);
             if (!string.IsNullOrWhiteSpace(restOfTemplate))

--- a/src/NuGetLicense/CommandLineOptionsParser.cs
+++ b/src/NuGetLicense/CommandLineOptionsParser.cs
@@ -16,9 +16,6 @@ using System.Net.Http;
 
 namespace NuGetLicense
 {
-    /// <summary>
-    /// Parses and transforms command line options into the format required by the license validation orchestrator.
-    /// </summary>
     public class CommandLineOptionsParser(IFileSystem fileSystem, HttpClient httpClient) : ICommandLineOptionsParser
     {
         public string[] GetInputFiles(string? inputFile, string? inputJsonFile)
@@ -151,7 +148,6 @@ namespace NuGetLicense
                 return [];
             }
 
-            // Check if the value is a path to an existing file
             if (fileSystem.File.Exists(value))
             {
                 try
@@ -166,9 +162,8 @@ namespace NuGetLicense
                 }
             }
 
-            // Parse as semicolon-separated inline values
             string[] parts = value.Split([';'], StringSplitOptions.RemoveEmptyEntries);
-            // Trim each part manually for .NET Framework compatibility
+            // net472 has no StringSplitOptions.TrimEntries.
             for (int i = 0; i < parts.Length; i++)
             {
                 parts[i] = parts[i].Trim();

--- a/src/NuGetLicense/ICommandLineOptionsParser.cs
+++ b/src/NuGetLicense/ICommandLineOptionsParser.cs
@@ -10,54 +10,24 @@ using NuGetUtility.Wrapper.HttpClientWrapper;
 
 namespace NuGetLicense
 {
-    /// <summary>
-    /// Parses and transforms command line options into the format required by the license validation orchestrator.
-    /// </summary>
     public interface ICommandLineOptionsParser
     {
-        /// <summary>
-        /// Gets the input files from the command line options.
-        /// </summary>
         string[] GetInputFiles(string? inputFile, string? inputJsonFile);
 
-        /// <summary>
-        /// Gets the allowed licenses from the command line options.
-        /// </summary>
         string[] GetAllowedLicenses(string? allowedLicenses);
 
-        /// <summary>
-        /// Gets the ignored packages from the command line options.
-        /// </summary>
         string[] GetIgnoredPackages(string? ignoredPackages);
 
-        /// <summary>
-        /// Gets the excluded projects from the command line options.
-        /// </summary>
         string[] GetExcludedProjects(string? excludedProjects);
 
-        /// <summary>
-        /// Gets the license mappings from the command line options.
-        /// </summary>
         IImmutableDictionary<Uri, string> GetLicenseMappings(string? licenseMapping);
 
-        /// <summary>
-        /// Gets the override package information from the command line options.
-        /// </summary>
         CustomPackageInformation[] GetOverridePackageInformation(string? overridePackageInformation);
 
-        /// <summary>
-        /// Gets the license file matcher from the command line options.
-        /// </summary>
         IFileLicenseMatcher GetLicenseMatcher(string? licenseFileMappings);
 
-        /// <summary>
-        /// Gets the file downloader from the command line options.
-        /// </summary>
         IFileDownloader GetFileDownloader(string? downloadLicenseInformation);
 
-        /// <summary>
-        /// Gets the output formatter from the command line options.
-        /// </summary>
         IOutputFormatter GetOutputFormatter(OutputType outputType, bool returnErrorsOnly, bool includeIgnoredPackages);
     }
 }

--- a/src/NuGetLicense/ILicenseValidationOrchestrator.cs
+++ b/src/NuGetLicense/ILicenseValidationOrchestrator.cs
@@ -3,17 +3,9 @@
 
 namespace NuGetLicense
 {
-    /// <summary>
-    /// Orchestrates the license validation process.
-    /// </summary>
     public interface ILicenseValidationOrchestrator
     {
-        /// <summary>
-        /// Orchestrates the license validation process and returns the exit code.
-        /// </summary>
-        /// <param name="options">The parsed command line options.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>Exit code: 0 for success, number of validation errors, or -1 for exceptions.</returns>
+        /// <returns>Exit code: 0 for success, the number of validation errors, or -1 on exception.</returns>
         Task<int> ValidateAsync(ICommandLineOptions options, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NuGetLicense/LicenseValidationOrchestrator.cs
+++ b/src/NuGetLicense/LicenseValidationOrchestrator.cs
@@ -23,9 +23,6 @@ using NuGetUtility.Wrapper.SolutionPersistenceWrapper;
 
 namespace NuGetLicense
 {
-    /// <summary>
-    /// Orchestrates the license validation process.
-    /// </summary>
     public class LicenseValidationOrchestrator(IFileSystem fileSystem,
                                                ISolutionPersistenceWrapper solutionPersistence,
                                                IMsBuildAbstraction msBuild,

--- a/src/NuGetLicense/Output/IOutputFormatter.cs
+++ b/src/NuGetLicense/Output/IOutputFormatter.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the project contributors.
 // The license conditions are provided in the LICENSE file located in the project root
 
-
-// Licensed to the projects contributors.
-// The license conditions are provided in the LICENSE file located in the project root
-
 using NuGetLicense.LicenseValidator;
 
 namespace NuGetLicense.Output

--- a/src/NuGetLicense/Program.cs
+++ b/src/NuGetLicense/Program.cs
@@ -70,7 +70,6 @@ namespace NuGetLicense
 
         public async Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken)
         {
-            // Check if mandatory parameters are provided
             if (InputFile == null && InputJsonFile == null)
             {
                 await Console.Error.WriteLineAsync("Error: Please provide an input file using --input or --json-input");

--- a/src/NuGetUtility/Extensions/HashSetExtension.cs
+++ b/src/NuGetUtility/Extensions/HashSetExtension.cs
@@ -8,10 +8,6 @@ namespace NuGetUtility.Extensions
         /// <summary>
         ///     Taken from https://stackoverflow.com/a/15267217/1199089
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="source"></param>
-        /// <param name="items"></param>
-        /// <returns></returns>
         public static bool AddRange<T>(this HashSet<T> source, IEnumerable<T> items)
         {
             bool allAdded = true;

--- a/src/NuGetUtility/Extensions/StringExtensions.cs
+++ b/src/NuGetUtility/Extensions/StringExtensions.cs
@@ -15,12 +15,7 @@ namespace NuGetUtility.Extensions
             return string.IsNullOrEmpty(value);
         }
 
-        /// <summary>
-        /// Compares the string against a given pattern.
-        /// </summary>
-        /// <param name="str">The string.</param>
-        /// <param name="pattern">The pattern to match, where "*" means any sequence of characters, and "?" means any single character.</param>
-        /// <returns><c>true</c> if the string matches the given pattern; otherwise <c>false</c>.</returns>
+        /// <summary>Matches case-insensitively, with "*" for any sequence of characters and "?" for any single character.</summary>
         public static bool Like(this string str, string pattern)
         {
             return new Regex(
@@ -30,12 +25,7 @@ namespace NuGetUtility.Extensions
             ).IsMatch(str);
         }
 
-        /// <summary>
-        /// Compares a path string against a given pattern, matching against both the full path and just the filename.
-        /// </summary>
-        /// <param name="path">The path string to match.</param>
-        /// <param name="pattern">The pattern to match, where "*" means any sequence of characters, and "?" means any single character.</param>
-        /// <returns><c>true</c> if either the full path or the filename matches the given pattern; otherwise <c>false</c>.</returns>
+        /// <summary>Matches the pattern against the full path and against the file name alone, so a bare "*.dll" also matches a nested path.</summary>
         public static bool PathLike(this string path, string pattern)
         {
             if (path.Like(pattern))
@@ -43,7 +33,7 @@ namespace NuGetUtility.Extensions
                 return true;
             }
 
-            // Extract the filename in a cross-platform way by finding the last path separator
+            // Path.GetFileName only honours the running platform's separator, so a Windows path would not split on Linux.
             int lastSeparatorIndex = Math.Max(path.LastIndexOf('/'), path.LastIndexOf('\\'));
             string fileName = lastSeparatorIndex >= 0 ? path[(lastSeparatorIndex + 1)..] : path;
             return fileName.Like(pattern);

--- a/src/NuGetUtility/ProjectFiltering/ProjectFilter.cs
+++ b/src/NuGetUtility/ProjectFiltering/ProjectFilter.cs
@@ -5,23 +5,11 @@ namespace NuGetUtility.ProjectFiltering
 {
     public static class ProjectFilter
     {
-
-        /// <summary>
-        /// Filters a collection of project paths based on inclusion rules.
-        /// </summary>
-        /// <param name="projects">Collection of project paths to filter</param>
-        /// <param name="includeSharedProjects">Whether to include .shproj files</param>
-        /// <returns>Filtered collection of project paths</returns>
         public static IEnumerable<string> FilterProjects(IEnumerable<string> projects, bool includeSharedProjects)
         {
             return includeSharedProjects ? projects : projects.Where(p => !IsSharedProject(p));
         }
 
-        /// <summary>
-        /// Determines if a project is a shared project based on file extension.
-        /// </summary>
-        /// <param name="projectPath">Path to the project file</param>
-        /// <returns>True if the project is a shared project, otherwise false</returns>
         private static bool IsSharedProject(string projectPath)
         {
             return projectPath.EndsWith(".shproj", StringComparison.OrdinalIgnoreCase);

--- a/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
+++ b/src/NuGetUtility/ReferencedPackagesReader/ReferencedPackageReader.cs
@@ -19,11 +19,6 @@ namespace NuGetUtility.ReferencedPackagesReader
     {
         private const string ProjectReferenceIdentifier = "project";
 
-        /// <summary>
-        /// Gets installed NuGet packages for the specified project.
-        /// </summary>
-        /// <param name="projectPath">Path to the project file.</param>
-        /// <param name="includeTransitive">True to include transitive dependencies; otherwise, false.</param>
         /// <param name="targetFramework">
         /// Target framework moniker to evaluate. If null, all available target frameworks are evaluated.
         /// </param>
@@ -144,7 +139,6 @@ namespace NuGetUtility.ReferencedPackagesReader
             string targetFrameworkForPublishMetadata = context.NormalizedRequestedTargetFramework ?? nuGetFrameworkUtility.Normalize(target.TargetFramework);
             string targetFrameworkCacheKey = targetFrameworkForPublishMetadata ?? string.Empty;
 
-            // Remove packages with Publish=false metadata from the evaluated PackageReferences for this target only.
             if (!context.PublishFalsePackagesByFramework.TryGetValue(targetFrameworkCacheKey, out HashSet<string>? cachedPublishFalsePackages))
             {
                 cachedPublishFalsePackages = GetPackagesExcludedFromPublish(project, targetFrameworkForPublishMetadata);

--- a/src/NuGetUtility/Wrapper/MsBuildWrapper/ProjectWrapper.cs
+++ b/src/NuGetUtility/Wrapper/MsBuildWrapper/ProjectWrapper.cs
@@ -36,7 +36,6 @@ namespace NuGetUtility.Wrapper.MsBuildWrapper
 
         public IEnumerable<PackageReferenceMetadata> GetPackageReferences()
         {
-            // Read evaluated PackageReference items from the current project context.
             return project.GetItems(PackageReferenceItemType)
                 .Select(item => new PackageReferenceMetadata(item.EvaluatedInclude, CreateMetadata(item)));
         }
@@ -67,7 +66,6 @@ namespace NuGetUtility.Wrapper.MsBuildWrapper
 
         private static IReadOnlyDictionary<string, string> CreateMetadata(ProjectItem item)
         {
-            // Normalize metadata names for case-insensitive lookups (e.g., Publish).
             Dictionary<string, string> metadata = new(StringComparer.OrdinalIgnoreCase);
             foreach (ProjectMetadata projectMetadata in item.Metadata)
             {

--- a/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/AssetsPackageDependencyReader.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/ProjectModel/AssetsPackageDependencyReader.cs
@@ -6,38 +6,17 @@ using NuGetUtility.Wrapper.NuGetWrapper.Frameworks;
 
 namespace NuGetUtility.Wrapper.NuGetWrapper.ProjectModel
 {
-    /// <summary>
-    /// Reads package dependency relationships from a NuGet assets file for a requested target framework.
-    /// </summary>
     public class AssetsPackageDependencyReader : IAssetsPackageDependencyReader
     {
         private const string PackageTypeIdentifier = "package";
         private readonly INuGetFrameworkUtility _nuGetFrameworkUtility;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AssetsPackageDependencyReader"/> class.
-        /// </summary>
-        /// <param name="nuGetFrameworkUtility">
-        /// Utility used to determine semantic equivalence between target framework representations.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when <paramref name="nuGetFrameworkUtility"/> is <see langword="null"/>.
-        /// </exception>
         public AssetsPackageDependencyReader(INuGetFrameworkUtility nuGetFrameworkUtility)
         {
             _nuGetFrameworkUtility = nuGetFrameworkUtility ?? throw new ArgumentNullException(nameof(nuGetFrameworkUtility));
         }
 
-        /// <summary>
-        /// Gets package-to-dependency mappings for libraries in the target framework section of the specified assets file.
-        /// </summary>
-        /// <param name="assetsPath">Path to the <c>project.assets.json</c> file to inspect.</param>
-        /// <param name="normalizedTargetFramework">Normalized target framework moniker used to select matching targets.</param>
-        /// <returns>
-        /// A dictionary that maps package IDs to a case-insensitive set of dependency package IDs
-        /// (<c>Dictionary&lt;string, HashSet&lt;string&gt;&gt;</c>).
-        /// Returns an empty dictionary when the assets file does not exist or cannot be read.
-        /// </returns>
+        /// <returns>Empty when the assets file does not exist or cannot be read.</returns>
         public Dictionary<string, HashSet<string>> GetPackageDependenciesForTargetFramework(ILockFile lockFile, string normalizedTargetFramework)
         {
             try

--- a/tests/NuGetLicense.Test/CommandLineOptionsParserTest.cs
+++ b/tests/NuGetLicense.Test/CommandLineOptionsParserTest.cs
@@ -43,13 +43,10 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetInputFiles_WithInputFile_ReturnsFileInArray()
             {
-                // Arrange
                 string inputFile = "/test/project.csproj";
 
-                // Act
                 string[] result = _parser.GetInputFiles(inputFile, null);
 
-                // Assert
                 await Assert.That(result).HasAtLeast(1);
                 await Assert.That(result[0]).IsEqualTo(inputFile);
             }
@@ -57,22 +54,18 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetInputFiles_WithInputJsonFile_ReadsAndDeserializesFile()
             {
-                // Arrange
                 string jsonFile = "/test/input.json";
                 string[] expectedFiles = ["/test/project1.csproj", "/test/project2.csproj"];
                 _fileSystem.AddFile(jsonFile, new MockFileData($"[\"{expectedFiles[0]}\",\"{expectedFiles[1]}\"]"));
 
-                // Act
                 string[] result = _parser.GetInputFiles(null, jsonFile);
 
-                // Assert
                 await Assert.That(result).IsEquivalentTo(expectedFiles);
             }
 
             [Test]
             public async Task GetInputFiles_WithNeitherOption_ThrowsArgumentException()
             {
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetInputFiles(null, null)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Please provide an input file using --input or --json-input");
@@ -81,15 +74,12 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetInputFiles_WithBothOptions_PrefersInputFile()
             {
-                // Arrange
                 string inputFile = "/test/project.csproj";
                 string jsonFile = "/test/input.json";
                 _fileSystem.AddFile(jsonFile, new MockFileData("[\"should_not_be_used.csproj\"]"));
 
-                // Act
                 string[] result = _parser.GetInputFiles(inputFile, jsonFile);
 
-                // Assert
                 await Assert.That(result).Count().IsEqualTo(1);
                 await Assert.That(result[0]).IsEqualTo(inputFile);
             }
@@ -100,62 +90,49 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetAllowedLicenses_WithNull_ReturnsEmptyArray()
             {
-                // Act
                 string[] result = _parser.GetAllowedLicenses(null);
 
-                // Assert
                 await Assert.That(result).IsEmpty();
             }
 
             [Test]
             public async Task GetAllowedLicenses_WithInlineList_ReturnsParsedArray()
             {
-                // Arrange
                 string allowedLicenses = "MIT;Apache-2.0;BSD-3-Clause";
 
-                // Act
                 string[] result = _parser.GetAllowedLicenses(allowedLicenses);
 
-                // Assert
                 await Assert.That(result).IsEquivalentTo(["MIT", "Apache-2.0", "BSD-3-Clause"]);
             }
 
             [Test]
             public async Task GetAllowedLicenses_WithFile_ReadsAndDeserializesFile()
             {
-                // Arrange
                 string licenseFile = "/test/allowed.json";
                 string[] expectedLicenses = ["MIT", "Apache-2.0"];
                 _fileSystem.AddFile(licenseFile, new MockFileData($"[\"{expectedLicenses[0]}\",\"{expectedLicenses[1]}\"]"));
 
-                // Act
                 string[] result = _parser.GetAllowedLicenses(licenseFile);
 
-                // Assert
                 await Assert.That(result).IsEquivalentTo(expectedLicenses);
             }
 
             [Test]
             public async Task GetAllowedLicenses_WithWhitespace_TrimsValues()
             {
-                // Arrange
                 string allowedLicenses = " MIT ; Apache-2.0 ; BSD-3-Clause ";
 
-                // Act
                 string[] result = _parser.GetAllowedLicenses(allowedLicenses);
 
-                // Assert
                 await Assert.That(result).IsEquivalentTo(["MIT", "Apache-2.0", "BSD-3-Clause"]);
             }
 
             [Test]
             public async Task GetAllowedLicenses_WithInvalidJsonFile_ThrowsArgumentException()
             {
-                // Arrange
                 string licenseFile = "/test/allowed.json";
                 _fileSystem.AddFile(licenseFile, new MockFileData("invalid json"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetAllowedLicenses(licenseFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Failed to parse JSON file");
@@ -167,38 +144,30 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetIgnoredPackages_WithNull_ReturnsEmptyArray()
             {
-                // Act
                 string[] result = _parser.GetIgnoredPackages(null);
 
-                // Assert
                 await Assert.That(result).IsEmpty();
             }
 
             [Test]
             public async Task GetIgnoredPackages_WithInlineList_ReturnsParsedArray()
             {
-                // Arrange
                 string ignoredPackages = "Package1;Package2;Package3";
 
-                // Act
                 string[] result = _parser.GetIgnoredPackages(ignoredPackages);
 
-                // Assert
                 await Assert.That(result).IsEquivalentTo(["Package1", "Package2", "Package3"]);
             }
 
             [Test]
             public async Task GetIgnoredPackages_WithFile_ReadsAndDeserializesFile()
             {
-                // Arrange
                 string packageFile = "/test/ignored.json";
                 string[] expectedPackages = ["MyCompany.*", "TestPackage"];
                 _fileSystem.AddFile(packageFile, new MockFileData($"[\"{expectedPackages[0]}\",\"{expectedPackages[1]}\"]"));
 
-                // Act
                 string[] result = _parser.GetIgnoredPackages(packageFile);
 
-                // Assert
                 await Assert.That(result).IsEquivalentTo(expectedPackages);
             }
         }
@@ -208,38 +177,30 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetExcludedProjects_WithNull_ReturnsEmptyArray()
             {
-                // Act
                 string[] result = _parser.GetExcludedProjects(null);
 
-                // Assert
                 await Assert.That(result).IsEmpty();
             }
 
             [Test]
             public async Task GetExcludedProjects_WithInlineList_ReturnsParsedArray()
             {
-                // Arrange
                 string excludedProjects = "*Test*;*.Test;Legacy*";
 
-                // Act
                 string[] result = _parser.GetExcludedProjects(excludedProjects);
 
-                // Assert
                 await Assert.That(result).IsEquivalentTo(["*Test*", "*.Test", "Legacy*"]);
             }
 
             [Test]
             public async Task GetExcludedProjects_WithFile_ReadsAndDeserializesFile()
             {
-                // Arrange
                 string projectFile = "/test/excluded.json";
                 string[] expectedProjects = ["*Test*", "*.Test"];
                 _fileSystem.AddFile(projectFile, new MockFileData($"[\"{expectedProjects[0]}\",\"{expectedProjects[1]}\"]"));
 
-                // Act
                 string[] result = _parser.GetExcludedProjects(projectFile);
 
-                // Assert
                 await Assert.That(result).IsEquivalentTo(expectedProjects);
             }
         }
@@ -249,10 +210,8 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetLicenseMappings_WithNull_ReturnsDefaultMapping()
             {
-                // Act
                 IImmutableDictionary<Uri, string> result = _parser.GetLicenseMappings(null);
 
-                // Assert
                 await Assert.That(result).IsNotNull();
                 await Assert.That(result.Count).IsGreaterThan(0); // Should contain default mappings
             }
@@ -260,16 +219,13 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetLicenseMappings_WithFile_MergesWithDefaultMappings()
             {
-                // Arrange
                 string mappingFile = "/test/mappings.json";
                 var customUrl = new Uri("https://example.com/license");
                 string customLicense = "CustomLicense";
                 _fileSystem.AddFile(mappingFile, new MockFileData($"{{\"{customUrl}\":\"{customLicense}\"}}"));
 
-                // Act
                 IImmutableDictionary<Uri, string> result = _parser.GetLicenseMappings(mappingFile);
 
-                // Assert
                 await Assert.That(result.ContainsKey(customUrl)).IsTrue();
                 await Assert.That(result[customUrl]).IsEqualTo(customLicense);
             }
@@ -280,24 +236,19 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithNull_ReturnsEmptyArray()
             {
-                // Act
                 CustomPackageInformation[] result = _parser.GetOverridePackageInformation(null);
 
-                // Assert
                 await Assert.That(result).IsEmpty();
             }
 
             [Test]
             public async Task GetOverridePackageInformation_WithFile_ReadsAndDeserializesFile()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[{\"Id\":\"TestPackage\",\"Version\":\"1.0.0\",\"License\":\"MIT\"}]"));
 
-                // Act
                 CustomPackageInformation[] result = _parser.GetOverridePackageInformation(overrideFile);
 
-                // Assert
                 await Assert.That(result).Count().IsEqualTo(1);
                 await Assert.That(result[0].Id).IsEqualTo("TestPackage");
                 await Assert.That(result[0].License).IsEqualTo("MIT");
@@ -306,11 +257,9 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithMissingId_ThrowsArgumentException()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[{\"Version\":\"1.0.0\",\"License\":\"MIT\"}]"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetOverridePackageInformation(overrideFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Failed to parse override package information file");
@@ -319,11 +268,9 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithMissingVersion_ThrowsArgumentException()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[{\"Id\":\"TestPackage\",\"License\":\"MIT\"}]"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetOverridePackageInformation(overrideFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Failed to parse override package information file");
@@ -332,11 +279,9 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithMissingLicense_ThrowsArgumentException()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[{\"Id\":\"TestPackage\",\"Version\":\"1.0.0\"}]"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetOverridePackageInformation(overrideFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Failed to parse override package information file");
@@ -345,11 +290,9 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithNullId_ThrowsArgumentException()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[{\"Id\":null,\"Version\":\"1.0.0\",\"License\":\"MIT\"}]"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetOverridePackageInformation(overrideFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Failed to parse override package information file");
@@ -358,11 +301,9 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithNullVersion_ThrowsArgumentException()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[{\"Id\":\"TestPackage\",\"Version\":null,\"License\":\"MIT\"}]"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetOverridePackageInformation(overrideFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Failed to parse override package information file");
@@ -371,11 +312,9 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithNullLicense_ThrowsArgumentException()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[{\"Id\":\"TestPackage\",\"Version\":\"1.0.0\",\"License\":null}]"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetOverridePackageInformation(overrideFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Failed to parse override package information file");
@@ -384,11 +323,9 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithInvalidVersion_ThrowsArgumentException()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[{\"Id\":\"TestPackage\",\"Version\":\"not-a-version\",\"License\":\"MIT\"}]"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetOverridePackageInformation(overrideFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Failed to parse override package information file");
@@ -397,7 +334,6 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithValidOptionalFields_DeserializesSuccessfully()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 string jsonContent = "[{" +
                     "\"Id\":\"TestPackage\"," +
@@ -413,10 +349,8 @@ namespace NuGetLicense.Test
                     "}]";
                 _fileSystem.AddFile(overrideFile, new MockFileData(jsonContent));
 
-                // Act
                 CustomPackageInformation[] result = _parser.GetOverridePackageInformation(overrideFile);
 
-                // Assert
                 await Assert.That(result).Count().IsEqualTo(1);
                 await Assert.That(result[0].Id).IsEqualTo("TestPackage");
                 await Assert.That(result[0].Version.ToString()).IsEqualTo("1.0.0");
@@ -433,14 +367,11 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithOnlyRequiredFields_DeserializesSuccessfully()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[{\"Id\":\"TestPackage\",\"Version\":\"2.1.0\",\"License\":\"Apache-2.0\"}]"));
 
-                // Act
                 CustomPackageInformation[] result = _parser.GetOverridePackageInformation(overrideFile);
 
-                // Assert
                 await Assert.That(result).Count().IsEqualTo(1);
                 await Assert.That(result[0].Id).IsEqualTo("TestPackage");
                 await Assert.That(result[0].Version.ToString()).IsEqualTo("2.1.0");
@@ -457,7 +388,6 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithMultiplePackages_DeserializesAll()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 string jsonContent = "[" +
                     "{\"Id\":\"Package1\",\"Version\":\"1.0.0\",\"License\":\"MIT\"}," +
@@ -466,10 +396,8 @@ namespace NuGetLicense.Test
                     "]";
                 _fileSystem.AddFile(overrideFile, new MockFileData(jsonContent));
 
-                // Act
                 CustomPackageInformation[] result = _parser.GetOverridePackageInformation(overrideFile);
 
-                // Assert
                 await Assert.That(result).Count().IsEqualTo(3);
                 await Assert.That(result[0].Id).IsEqualTo("Package1");
                 await Assert.That(result[0].License).IsEqualTo("MIT");
@@ -482,11 +410,9 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithInvalidJson_ThrowsArgumentException()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("not valid json"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetOverridePackageInformation(overrideFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("Failed to parse override package information file");
@@ -495,11 +421,9 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithNullContent_ThrowsArgumentException()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("null"));
 
-                // Act & Assert
                 ArgumentException? ex = await Assert.That(() =>
                     _parser.GetOverridePackageInformation(overrideFile)).Throws<ArgumentException>();
                 await Assert.That(ex!.Message).Contains("expected an array of package information but got null");
@@ -508,14 +432,11 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOverridePackageInformation_WithEmptyArray_ReturnsEmptyArray()
             {
-                // Arrange
                 string overrideFile = "/test/override.json";
                 _fileSystem.AddFile(overrideFile, new MockFileData("[]"));
 
-                // Act
                 CustomPackageInformation[] result = _parser.GetOverridePackageInformation(overrideFile);
 
-                // Assert
                 await Assert.That(result).IsEmpty();
             }
         }
@@ -525,10 +446,8 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetLicenseMatcher_WithNull_ReturnsSpdxMatcher()
             {
-                // Act
                 IFileLicenseMatcher result = _parser.GetLicenseMatcher(null);
 
-                // Assert
                 await Assert.That(result).IsNotNull();
                 await Assert.That(result).IsTypeOf<FileLicenseMatcher.SPDX.FastLicenseMatcher>();
             }
@@ -536,16 +455,13 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetLicenseMatcher_WithFile_ReturnsCombinedMatcher()
             {
-                // Arrange
                 string mappingFile = "/test/dir/license-mappings.json";
                 string licenseFile = "/test/dir/LICENSE.txt";
                 _fileSystem.AddFile(licenseFile, new MockFileData("MIT License content"));
                 _fileSystem.AddFile(mappingFile, new MockFileData("{\"LICENSE.txt\":\"MIT\"}"));
 
-                // Act
                 IFileLicenseMatcher result = _parser.GetLicenseMatcher(mappingFile);
 
-                // Assert
                 await Assert.That(result).IsNotNull();
                 await Assert.That(result).IsTypeOf<FileLicenseMatcher.Combine.LicenseMatcher>();
             }
@@ -556,23 +472,18 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetFileDownloader_WithNull_ReturnsNopDownloader()
             {
-                // Act
                 IFileDownloader result = _parser.GetFileDownloader(null);
 
-                // Assert
                 await Assert.That(result).IsTypeOf<NopFileDownloader>();
             }
 
             [Test]
             public async Task GetFileDownloader_WithDirectory_CreatesDirectoryAndReturnsFileDownloader()
             {
-                // Arrange
                 string downloadDir = "/test/downloads";
 
-                // Act
                 IFileDownloader result = _parser.GetFileDownloader(downloadDir);
 
-                // Assert
                 await Assert.That(result).IsTypeOf<FileDownloader>();
                 await Assert.That(_fileSystem.Directory.Exists(downloadDir)).IsTrue();
             }
@@ -580,14 +491,11 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetFileDownloader_WithExistingDirectory_ReturnsFileDownloader()
             {
-                // Arrange
                 string downloadDir = "/test/downloads";
                 _fileSystem.AddDirectory(downloadDir);
 
-                // Act
                 IFileDownloader result = _parser.GetFileDownloader(downloadDir);
 
-                // Assert
                 await Assert.That(result).IsTypeOf<FileDownloader>();
             }
         }
@@ -597,47 +505,38 @@ namespace NuGetLicense.Test
             [Test]
             public async Task GetOutputFormatter_WithTable_ReturnsTableFormatter()
             {
-                // Act
                 LicenseOutput.IOutputFormatter result = _parser.GetOutputFormatter(OutputType.Table, false, false);
 
-                // Assert
                 await Assert.That(result).IsTypeOf<LicenseOutput.Table.TableOutputFormatter>();
             }
 
             [Test]
             public async Task GetOutputFormatter_WithMarkdown_ReturnsTableFormatter()
             {
-                // Act
                 LicenseOutput.IOutputFormatter result = _parser.GetOutputFormatter(OutputType.Markdown, false, false);
 
-                // Assert
                 await Assert.That(result).IsTypeOf<LicenseOutput.Table.TableOutputFormatter>();
             }
 
             [Test]
             public async Task GetOutputFormatter_WithJson_ReturnsJsonFormatter()
             {
-                // Act
                 LicenseOutput.IOutputFormatter result = _parser.GetOutputFormatter(OutputType.Json, false, false);
 
-                // Assert
                 await Assert.That(result).IsTypeOf<LicenseOutput.Json.JsonOutputFormatter>();
             }
 
             [Test]
             public async Task GetOutputFormatter_WithJsonPretty_ReturnsJsonFormatter()
             {
-                // Act
                 LicenseOutput.IOutputFormatter result = _parser.GetOutputFormatter(OutputType.JsonPretty, false, false);
 
-                // Assert
                 await Assert.That(result).IsTypeOf<LicenseOutput.Json.JsonOutputFormatter>();
             }
 
             [Test]
             public async Task GetOutputFormatter_WithInvalidType_ThrowsArgumentOutOfRangeException()
             {
-                // Act & Assert
                 await Assert.That(() =>
                     _parser.GetOutputFormatter((OutputType)999, false, false)).Throws<ArgumentOutOfRangeException>();
             }

--- a/tests/NuGetLicense.Test/LicenseValidationOrchestratorTest.cs
+++ b/tests/NuGetLicense.Test/LicenseValidationOrchestratorTest.cs
@@ -57,7 +57,6 @@ namespace NuGetLicense.Test
         [Test]
         public async Task ValidateAsync_CallsOptionsParserWithCorrectArguments()
         {
-            // Arrange
             _options.InputFile.Returns("/test/project.csproj");
             _options.AllowedLicenses.Returns("MIT");
             _options.IgnoredPackages.Returns("TestPkg");
@@ -75,10 +74,8 @@ namespace NuGetLicense.Test
 
             _solutionPersistence.GetProjectsFromSolutionAsync(Arg.Any<string>()).Returns(Task.FromResult<IEnumerable<string>>([]));
 
-            // Act
             await _orchestrator.ValidateAsync(_options);
 
-            // Assert
             _optionsParser.Received(1).GetInputFiles(_options.InputFile, _options.InputJsonFile);
             _optionsParser.Received(1).GetAllowedLicenses(_options.AllowedLicenses);
             _optionsParser.Received(1).GetIgnoredPackages(_options.IgnoredPackages);
@@ -88,23 +85,19 @@ namespace NuGetLicense.Test
         [Test]
         public async Task ValidateAsync_WithNoProjects_ReturnsZero()
         {
-            // Arrange
             _options.InputFile.Returns("/test/project.csproj");
 
             SetupDefaultMocks();
             _solutionPersistence.GetProjectsFromSolutionAsync(Arg.Any<string>()).Returns(Task.FromResult<IEnumerable<string>>([]));
 
-            // Act
             int result = await _orchestrator.ValidateAsync(_options);
 
-            // Assert
             await Assert.That(result).IsEqualTo(0);
         }
 
         [Test]
         public async Task ValidateAsync_WithDestinationFile_WritesToFile()
         {
-            // Arrange
             string destinationFile = "/test/output.txt";
             _fileSystem.AddDirectory("/test");
             _options.InputFile.Returns("/test/project.csproj");
@@ -113,10 +106,8 @@ namespace NuGetLicense.Test
             SetupDefaultMocks();
             _solutionPersistence.GetProjectsFromSolutionAsync(Arg.Any<string>()).Returns(Task.FromResult<IEnumerable<string>>([]));
 
-            // Act
             int result = await _orchestrator.ValidateAsync(_options);
 
-            // Assert
             await Assert.That(result).IsEqualTo(0);
             await Assert.That(_fileSystem.File.Exists(destinationFile)).IsTrue();
         }
@@ -124,7 +115,6 @@ namespace NuGetLicense.Test
         [Test]
         public async Task ValidateAsync_WithDestinationFileInNonExistentDirectory_CreatesDirectoryAndWritesToFile()
         {
-            // Arrange
             string destinationFile = "/nonexistent/subdir/output.txt";
             _options.InputFile.Returns("/test/project.csproj");
             _options.DestinationFile.Returns(destinationFile);
@@ -132,10 +122,8 @@ namespace NuGetLicense.Test
             SetupDefaultMocks();
             _solutionPersistence.GetProjectsFromSolutionAsync(Arg.Any<string>()).Returns(Task.FromResult<IEnumerable<string>>([]));
 
-            // Act
             int result = await _orchestrator.ValidateAsync(_options);
 
-            // Assert
             await Assert.That(result).IsEqualTo(0);
             await Assert.That(_fileSystem.File.Exists(destinationFile)).IsTrue();
             await Assert.That(_fileSystem.Directory.Exists("/nonexistent/subdir")).IsTrue();
@@ -144,16 +132,13 @@ namespace NuGetLicense.Test
         [Test]
         public async Task ValidateAsync_WithoutDestinationFile_WritesToOutputStream()
         {
-            // Arrange
             _options.InputFile.Returns("/test/project.csproj");
 
             SetupDefaultMocks();
             _solutionPersistence.GetProjectsFromSolutionAsync(Arg.Any<string>()).Returns(Task.FromResult<IEnumerable<string>>([]));
 
-            // Act
             int result = await _orchestrator.ValidateAsync(_options);
 
-            // Assert
             await Assert.That(result).IsEqualTo(0);
             await Assert.That(_outputStream.Length).IsGreaterThan(0);
         }
@@ -161,7 +146,6 @@ namespace NuGetLicense.Test
         [Test]
         public async Task ValidateAsync_WithExceptionInOutputFormatter_ReturnsMinusOne()
         {
-            // Arrange
             _options.InputFile.Returns("/test/project.csproj");
 
             SetupDefaultMocks();
@@ -172,10 +156,8 @@ namespace NuGetLicense.Test
                 .Returns(_ => throw new InvalidOperationException("Test exception"));
             _optionsParser.GetOutputFormatter(OutputType.Table, false, false).Returns(throwingFormatter);
 
-            // Act
             int result = await _orchestrator.ValidateAsync(_options);
 
-            // Assert
             await Assert.That(result).IsEqualTo(-1);
             await Assert.That(_errorStream.Length).IsGreaterThan(0);
         }
@@ -183,7 +165,6 @@ namespace NuGetLicense.Test
         [Test]
         public async Task ValidateAsync_WithCancellationToken_CanBeCancelled()
         {
-            // Arrange
             _options.InputFile.Returns("/test/project.csproj");
 
             SetupDefaultMocks();
@@ -202,7 +183,6 @@ namespace NuGetLicense.Test
         [Test]
         public async Task ValidateAsync_UsesAllConfiguredOptions()
         {
-            // Arrange
             _options.InputFile.Returns("/test/project.csproj");
             _options.IncludeTransitive.Returns(true);
             _options.TargetFramework.Returns("net8.0");
@@ -218,10 +198,8 @@ namespace NuGetLicense.Test
             SetupDefaultMocks();
             _solutionPersistence.GetProjectsFromSolutionAsync(Arg.Any<string>()).Returns(Task.FromResult<IEnumerable<string>>([]));
 
-            // Act
             await _orchestrator.ValidateAsync(_options);
 
-            // Assert
             _optionsParser.Received(1).GetInputFiles(_options.InputFile, _options.InputJsonFile);
             _optionsParser.Received(1).GetAllowedLicenses(_options.AllowedLicenses);
             _optionsParser.Received(1).GetIgnoredPackages(_options.IgnoredPackages);

--- a/tests/NuGetUtility.Test/ReferencedPackagesReader/ProjectsCollectorTest.cs
+++ b/tests/NuGetUtility.Test/ReferencedPackagesReader/ProjectsCollectorTest.cs
@@ -159,7 +159,7 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
         private string GetPathRelativeTo(string relativeTo, string path)
 #if NETFRAMEWORK
         {
-            // Require trailing backslash for path
+            // MakeRelativeUri treats a base without a trailing separator as a file rather than a directory.
             relativeTo = relativeTo.TrimEnd(_fileSystem.Path.DirectorySeparatorChar, _fileSystem.Path.AltDirectorySeparatorChar);
             relativeTo += _fileSystem.Path.DirectorySeparatorChar;
 

--- a/tests/NuGetUtility.UrlToLicenseMapping.Test/UrlToLicenseMappingTest.cs
+++ b/tests/NuGetUtility.UrlToLicenseMapping.Test/UrlToLicenseMappingTest.cs
@@ -43,7 +43,6 @@ namespace NuGetUtility.Test.UrlToLicenseMapping
             using var slot = new DriverSlot(s_driverSlots);
             await slot.WaitAsync();
 
-            // Grab an existing driver from the pool, or create a new one if the pool is empty
             if (!s_driverPool.TryDequeue(out DisposableWebDriver? driver))
             {
                 driver = new DisposableWebDriver();
@@ -80,7 +79,6 @@ namespace NuGetUtility.Test.UrlToLicenseMapping
             }
             finally
             {
-                // Return the driver back to the pool so the next test case can reuse it
                 if (runSucceeded)
                 {
                     s_driverPool.Enqueue(driver);


### PR DESCRIPTION
Cuts comments that restate the code they sit on, so the code carries itself.

Kept are the ones that explain something the code cannot show: the net472 API gaps (`StringSplitOptions.TrimEntries`, `HttpStatusCode.TooManyRequests`, the nullability annotation), the `MakeRelativeUri` base-path requirement, the content-hash cache rationale in `PackageInformationReader`, the `AppLifetime` shutdown ordering, and the attributions for borrowed code.

The `// Arrange` / `// Act` / `// Assert` markers go. Those tests already sit in named nested classes, and the blank lines keep the phases apart without labelling them.

Two blocks were stale rather than just redundant, which is the argument for not keeping documentation that nothing forces you to update:

- `IOutputFormatter.cs` carried the licence header twice, the second copy reading "the projects contributors".
- `GetPackageDependenciesForTargetFramework` documented an `assetsPath` parameter it does not take.

In the README, project-type support was stated once in the Project Structure table and again in the Compatibility Matrix. The matrix now carries it alone, with the partial-support footnote moved onto the cell it qualifies.

No behaviour change; the format check and the test suites pass unchanged.

## Left alone deliberately

`src/FileLicenseMatcher/SPDX/JavaCore` and `JavaLibrary` keep their Javadoc-style blocks. They are a port of the Java SPDX library and the comments track upstream, so stripping them is a call for you rather than a drive-by. Worth knowing that `/** ... {@link X} */` does not render as C# XML docs, if you ever want them converted.

`docs/*.md` is untouched. It documents JSON file formats that users hand-author, so it is reference material rather than code that should speak for itself.

## Separate finding, not fixed here

`HashSetExtension.AddRange` initialises `allAdded` to `true` and never reassigns it, so it always returns `true` while `HashSet.Add`'s result is discarded. It is latent: no caller reads the return value and no test asserts on it. Making it `void` is a behaviour change, so it wants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project documentation tables and clarified the compatibility note for partial .NET Framework support.
  - Streamlined XML documentation and inline comments throughout the codebase.

- **Tests**
  - Simplified test files by removing redundant section and explanatory comments without changing test logic or assertions.

- **Maintenance**
  - Updated a license header and normalized file formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->