### PR TITLE
Retry the url-to-license test on an empty response

### DIFF
--- a/tests/NuGetUtility.UrlToLicenseMapping.Test/UrlToLicenseMappingTest.cs
+++ b/tests/NuGetUtility.UrlToLicenseMapping.Test/UrlToLicenseMappingTest.cs
@@ -103,6 +103,14 @@ namespace NuGetUtility.Test.UrlToLicenseMapping
                 return new() { Error = $"Failed to navigate to {licenseUrl}.\n{e}" };
             }
 
+            // An anti-bot interstitial answers 200 with nothing readable in it, which would
+            // otherwise be verified as if it were the licence and fail the comparison instead
+            // of being retried.
+            if (string.IsNullOrWhiteSpace(bodyText))
+            {
+                return new() { Error = $"Empty response from {licenseUrl}." };
+            }
+
             if (bodyText.Contains("rate limit", StringComparison.OrdinalIgnoreCase))
             {
                 return new() { Error = $"Rate limit exceeded:\n{bodyText}" };


### PR DESCRIPTION
A refusal from one of the mapped sites answers 200 with nothing readable in the body. `GetLicenseValue` returned that as a successful read, so the retry loop never fired for it and the empty string went to `Verify`, which failed on the snapshot comparison naming neither the URL nor the reason. That is the failure that went red on main this morning.

Treating an empty body as an error routes it through the retry and backoff that already exist, and the message now names the URL.

## What this buys

It narrows the window rather than closing it. The test drives twenty live third-party sites, so it stays red whenever one of them refuses for longer than the three retries span, which is a little under four minutes.

It also makes the failure legible. Running against a host that is refusing now reports `Empty response from <url>` instead of a snapshot diff against the expected licence text.

## Verification

Green here, 20 of 20, with no retry triggered, so this run exercised the unchanged path only.

The new path was exercised locally instead: `max.mit-license.org` was answering 503 to my address at the time, including to plain curl and regardless of user agent, while still serving the CI runner normally. Under that, the suite gives 19 passes and one `Empty response from http://max.mit-license.org/` raised after the retries are spent, which is the intended behaviour.

No unit test for the guard itself. An empty body is never a valid licence, and asserting it would mean standing up a test double for Selenium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
